### PR TITLE
Fix language switcher layout

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -22,7 +22,11 @@ function initLanguageSwitcher() {
     const lang = languageSelect.value || "ru";
     document.querySelectorAll(".lang").forEach((element) => {
       const isVisible = element.getAttribute("data-lang") === lang;
-      element.style.display = isVisible ? "block" : "none";
+      element.hidden = !isVisible;
+      element.setAttribute("aria-hidden", isVisible ? "false" : "true");
+      if (isVisible) {
+        element.style.removeProperty("display");
+      }
     });
   };
 


### PR DESCRIPTION
## Summary
- stop the language switcher from forcing elements to `display: block`, which broke the navigation layout
- use the `hidden` attribute plus `aria-hidden` updates to toggle the translated elements while preserving their natural styling

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198f209d2c8329b2b655daba782d0b)