### PR TITLE
Refresh book list UI and loading logic

### DIFF
--- a/book.html
+++ b/book.html
@@ -8,19 +8,8 @@
     <meta name="author" content="Maksat Döwletow">
     <title>Медицинская электронная библиотека — список книг</title>
     <link rel="stylesheet" href="styles.css">
-    <style>
-        table tr:hover {
-            background-color: #f1f1f1;
-        }
-        table tr:nth-child(even) {
-            background-color: #a5aa95;
-        }
-        table tr:nth-child(odd) {
-            background-color: #fff;
-        }
-    </style>
 </head>
-<body>
+<body class="book-page">
   <header>
     <select id="language-select">
       <option value="tm">Türkmençe</option>
@@ -43,25 +32,57 @@
     <a href="book.html" data-lang="tm" class="lang">Kitaplar</a>
     <a href="https://sites.google.com/view/lukmanylyksanlykitaphanasy/ba%C5%9F-sahypa" target="_blank" class="external-link" style="color: blue; font-weight: bold;">Другой сайт библиотеки</a>
   </nav>
-  <section class="search" aria-label="Поиск по книгам">
-      <input type="text" id="searchInput" placeholder="Gözleg..." aria-label="Поиск по названию или автору">
-  </section>
-  <div style="height: 300px; overflow-y: auto;">
-    <table id="book-table" class="styled-table">
-      <thead>
-        <tr>
-          <th>Название книги</th>
-          <th>Имя автора</th>
-          <th>Издатель</th>
-          <th>Город публикации</th>
-          <th>Год публикации</th>
-          <th>Количество страниц</th>
-          <th>Язык книги</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-  </div>
+  <main class="page-container" aria-label="Каталог книг">
+    <section class="table-panel">
+      <div class="panel-header">
+        <div>
+          <p data-lang="ru" class="lang panel-subtitle">Быстрый поиск по каталогу библиотеки</p>
+          <p data-lang="en" class="lang panel-subtitle">Quick search across the library catalogue</p>
+          <p data-lang="tm" class="lang panel-subtitle">Kitaphana katalogy boýunça çalt gözleg</p>
+        </div>
+        <p id="book-status" class="table-status" role="status" aria-live="polite">Загружаем каталог...</p>
+      </div>
+      <section class="search" aria-label="Поиск по книгам">
+        <label for="searchInput" class="visually-hidden">Поиск по названию или автору</label>
+        <div class="search-field">
+          <input type="text" id="searchInput" placeholder="Gözleg..." autocomplete="off">
+          <button type="button" id="clear-search" class="search-clear" aria-label="Очистить поиск">&times;</button>
+        </div>
+      </section>
+      <div class="table-wrapper" role="region" aria-live="polite">
+        <table id="book-table" class="styled-table">
+          <thead>
+            <tr>
+              <th>Название книги</th>
+              <th>Имя автора</th>
+              <th>Издатель</th>
+              <th>Город публикации</th>
+              <th>Год публикации</th>
+              <th>Количество страниц</th>
+              <th>Язык книги</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="skeleton-row" aria-hidden="true">
+              <td colspan="7"></td>
+            </tr>
+            <tr class="skeleton-row" aria-hidden="true">
+              <td colspan="7"></td>
+            </tr>
+            <tr class="skeleton-row" aria-hidden="true">
+              <td colspan="7"></td>
+            </tr>
+            <tr class="skeleton-row" aria-hidden="true">
+              <td colspan="7"></td>
+            </tr>
+            <tr class="skeleton-row" aria-hidden="true">
+              <td colspan="7"></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </section>
+  </main>
   <footer>
     <div class="footer-container">
       <div class="contact-info">

--- a/scripts.js
+++ b/scripts.js
@@ -22,7 +22,11 @@ function initLanguageSwitcher() {
     const lang = languageSelect.value || "ru";
     document.querySelectorAll(".lang").forEach((element) => {
       const isVisible = element.getAttribute("data-lang") === lang;
-      element.style.display = isVisible ? "block" : "none";
+      element.hidden = !isVisible;
+      element.setAttribute("aria-hidden", isVisible ? "false" : "true");
+      if (isVisible) {
+        element.style.removeProperty("display");
+      }
     });
   };
 
@@ -304,44 +308,143 @@ function initLoginForm(apiBase) {
 
 function initSearchFilter() {
   const searchInput = document.getElementById("searchInput");
-  if (!searchInput) {
+  const tableBody = document.querySelector("#book-table tbody");
+  if (!searchInput || !tableBody) {
     return;
   }
 
-  searchInput.addEventListener("input", () => {
-    const filter = searchInput.value.toUpperCase();
-    const table = document.querySelector("#book-table tbody");
-    if (!table) {
+  const clearButton = document.getElementById("clear-search");
+  const statusElement = document.getElementById("book-status");
+  let isTableReady = false;
+  let totalRows = 0;
+
+  const updateStatus = (visibleRows) => {
+    if (!statusElement) {
       return;
     }
 
-    const rows = table.getElementsByTagName("tr");
-    for (let i = 0; i < rows.length; i += 1) {
-      const cells = rows[i].getElementsByTagName("td");
+    if (!totalRows) {
+      return;
+    }
+
+    if (!visibleRows) {
+      statusElement.textContent = "Ничего не найдено";
+      statusElement.dataset.state = "error";
+      return;
+    }
+
+    const prefix = visibleRows === totalRows ? "Показаны" : "Найдено";
+    statusElement.textContent = `${prefix} ${visibleRows} из ${totalRows} записей`;
+    statusElement.dataset.state = "success";
+  };
+
+  const filterRows = () => {
+    clearButton?.classList.toggle("is-visible", Boolean(searchInput.value));
+
+    if (!isTableReady) {
+      return;
+    }
+
+    const filter = searchInput.value.trim().toUpperCase();
+    const rows = Array.from(tableBody.rows).filter(
+      (row) => !row.classList.contains("skeleton-row")
+    );
+    let visibleCount = 0;
+
+    rows.forEach((row) => {
+      const cells = row.getElementsByTagName("td");
       if (!cells.length) {
-        continue;
+        return;
       }
 
-      const bookTitle = cells[0].textContent || cells[0].innerText;
-      const author = cells[1].textContent || cells[1].innerText;
+      const bookTitle = cells[0].textContent || "";
+      const author = cells[1].textContent || "";
       const matches =
+        !filter ||
         bookTitle.toUpperCase().includes(filter) ||
         author.toUpperCase().includes(filter);
-      rows[i].style.display = matches ? "" : "none";
+
+      row.style.display = matches ? "" : "none";
+      if (matches) {
+        visibleCount += 1;
+      }
+    });
+
+    totalRows = rows.length;
+    updateStatus(visibleCount);
+  };
+
+  const debouncedFilter = debounce(filterRows, 160);
+  searchInput.addEventListener("input", debouncedFilter);
+
+  clearButton?.addEventListener("click", () => {
+    if (!searchInput.value) {
+      return;
     }
+    searchInput.value = "";
+    filterRows();
+    searchInput.focus();
+  });
+
+  tableBody.addEventListener("booktable:ready", (event) => {
+    isTableReady = true;
+    totalRows = event?.detail?.totalRows ?? tableBody.rows.length;
+    filterRows();
   });
 }
 
 function initBookTable() {
   const bookTableBody = document.querySelector("#book-table tbody");
+  const statusElement = document.getElementById("book-status");
   if (!bookTableBody) {
     return;
   }
 
   if (typeof XLSX === "undefined") {
     console.error("XLSX library is not loaded");
+    if (statusElement) {
+      statusElement.textContent = "Библиотека недоступна";
+      statusElement.dataset.state = "error";
+    }
     return;
   }
+
+  const tablePanel = document.querySelector(".table-panel");
+  const setTableStatus = (message, state) => {
+    if (!statusElement) {
+      return;
+    }
+    statusElement.textContent = message;
+    if (state) {
+      statusElement.dataset.state = state;
+    } else {
+      delete statusElement.dataset.state;
+    }
+  };
+
+  tablePanel?.classList.add("is-loading");
+  setTableStatus("Загружаем каталог...", "pending");
+
+  const columns = [
+    "Название книги",
+    "Имя автора",
+    "Издатель",
+    "Город публикации",
+    "Год публикации",
+    "Количество страниц",
+    "Язык книги",
+  ];
+  const MAX_ROWS = 1400;
+  const CHUNK_SIZE = 200;
+
+  const dispatchReady = (totalRows) => {
+    bookTableBody.dispatchEvent(
+      new CustomEvent("booktable:ready", {
+        bubbles: true,
+        detail: { totalRows },
+      })
+    );
+  };
 
   fetch("Book.xls")
     .then((response) => {
@@ -354,20 +457,56 @@ function initBookTable() {
       const workbook = XLSX.read(data, { type: "array" });
       const firstSheet = workbook.Sheets[workbook.SheetNames[0]];
       const jsonData = XLSX.utils.sheet_to_json(firstSheet);
+      const rows = jsonData.slice(0, MAX_ROWS).map((row) =>
+        columns.map((column) => row[column] || "")
+      );
+
+      if (!rows.length) {
+        tablePanel?.classList.remove("is-loading");
+        tablePanel?.classList.add("is-ready");
+        bookTableBody.innerHTML = "";
+        setTableStatus("Каталог пуст", "error");
+        dispatchReady(0);
+        return;
+      }
+
       bookTableBody.innerHTML = "";
-      jsonData.slice(0, 1400).forEach((row) => {
-        const tr = document.createElement("tr");
-        tr.innerHTML = `<td>${row["Название книги"] || ""}</td>
-                        <td>${row["Имя автора"] || ""}</td>
-                        <td>${row["Издатель"] || ""}</td>
-                        <td>${row["Город публикации"] || ""}</td>
-                        <td>${row["Год публикации"] || ""}</td>
-                        <td>${row["Количество страниц"] || ""}</td>
-                        <td>${row["Язык книги"] || ""}</td>`;
-        bookTableBody.appendChild(tr);
-      });
+      let startIndex = 0;
+      const totalRows = rows.length;
+
+      const renderChunk = () => {
+        const fragment = document.createDocumentFragment();
+        const limit = Math.min(startIndex + CHUNK_SIZE, totalRows);
+        for (let i = startIndex; i < limit; i += 1) {
+          const tr = document.createElement("tr");
+          rows[i].forEach((cellValue) => {
+            const td = document.createElement("td");
+            td.textContent = cellValue;
+            tr.appendChild(td);
+          });
+          fragment.appendChild(tr);
+        }
+        bookTableBody.appendChild(fragment);
+        startIndex = limit;
+        if (startIndex < totalRows) {
+          window.requestAnimationFrame(renderChunk);
+        } else {
+          tablePanel?.classList.remove("is-loading");
+          tablePanel?.classList.add("is-ready");
+          setTableStatus(`Показаны ${totalRows} записей`, "success");
+          dispatchReady(totalRows);
+        }
+      };
+
+      renderChunk();
     })
-    .catch((error) => console.error("Error:", error));
+    .catch((error) => {
+      console.error("Error:", error);
+      tablePanel?.classList.remove("is-loading");
+      tablePanel?.classList.add("is-ready");
+      bookTableBody.innerHTML = "";
+      setTableStatus("Не удалось загрузить каталог. Попробуйте позже.", "error");
+    });
 }
 
 function setStatusMessage(element, message, state) {
@@ -394,6 +533,17 @@ function isEmailValid(email) {
 function buildEndpoint(apiBase, path) {
   const normalizedPath = path.startsWith("/") ? path : `/${path}`;
   return apiBase ? `${apiBase}${normalizedPath}` : normalizedPath;
+}
+
+function debounce(callback, delay = 200) {
+  let timeoutId;
+  return function debounced(...args) {
+    const context = this;
+    window.clearTimeout(timeoutId);
+    timeoutId = window.setTimeout(() => {
+      callback.apply(context, args);
+    }, delay);
+  };
 }
 
 window.sendMail = () => {

--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,48 @@ body {
     background-color: #f4f4f4;
 }
 
+body.book-page {
+    background: linear-gradient(135deg, #eff2f7 0%, #ffffff 55%, #f7fbff 100%);
+    min-height: 100vh;
+}
+
+.book-page header {
+    background: linear-gradient(135deg, #0d324d, #7f5a83);
+    color: #fff;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    text-align: left;
+}
+
+.book-page header h1 {
+    margin: 0;
+}
+
+#language-select {
+    border-radius: 999px;
+    border: none;
+    padding: 0.45rem 1.5rem;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+    backdrop-filter: blur(6px);
+    cursor: pointer;
+}
+
+#language-select option {
+    color: #111;
+}
+
+@media (min-width: 768px) {
+    .book-page header {
+        justify-content: space-between;
+        padding-inline: 3rem;
+    }
+}
+
 #auth {
     max-width: 360px;
     margin: 1rem auto;
@@ -184,6 +226,150 @@ nav a:hover {
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
+.page-container {
+    padding: clamp(1rem, 4vw, 2.5rem);
+    max-width: 1200px;
+    margin: 0 auto 3rem;
+}
+
+.table-panel {
+    background: #fff;
+    border-radius: 24px;
+    padding: clamp(1rem, 4vw, 2.5rem);
+    box-shadow: 0 25px 60px rgba(15, 28, 63, 0.12);
+    border: 1px solid #eef1f5;
+}
+
+.panel-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 1.25rem;
+}
+
+.panel-subtitle {
+    margin: 0;
+    color: #4a4f63;
+    font-weight: 500;
+}
+
+.table-status {
+    margin: 0;
+    font-weight: 600;
+    color: #4a5568;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: #f1f5f9;
+}
+
+.table-status[data-state="pending"] {
+    color: #b7791f;
+    background: #fff8eb;
+}
+
+.table-status[data-state="error"] {
+    color: #c53030;
+    background: #ffe5e5;
+}
+
+.table-status[data-state="success"] {
+    color: #0f7a42;
+    background: #e6f6ee;
+}
+
+.table-panel.is-loading .table-status::after {
+    content: "";
+    margin-left: 0.5rem;
+    width: 0.85rem;
+    height: 0.85rem;
+    border: 2px solid currentColor;
+    border-bottom-color: transparent;
+    border-radius: 50%;
+    display: inline-block;
+    animation: spin 0.6s linear infinite;
+    vertical-align: middle;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.search {
+    margin-bottom: 1rem;
+}
+
+.search-field {
+    position: relative;
+}
+
+#searchInput {
+    width: 100%;
+    padding: 0.85rem 2.5rem 0.85rem 1rem;
+    border-radius: 14px;
+    border: 1px solid #dbe2f0;
+    font-size: 1rem;
+    background: #f6f8fc;
+    transition: border-color var(--transition), box-shadow var(--transition);
+    box-sizing: border-box;
+}
+
+#searchInput:focus {
+    border-color: #7f5a83;
+    box-shadow: 0 0 0 3px rgba(127, 90, 131, 0.2);
+    outline: none;
+}
+
+.search-clear {
+    position: absolute;
+    right: 0.4rem;
+    top: 50%;
+    transform: translateY(-50%);
+    border: none;
+    background: transparent;
+    font-size: 1.25rem;
+    cursor: pointer;
+    color: #7f8ba3;
+    padding: 0.25rem 0.75rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: color var(--transition), opacity var(--transition);
+}
+
+.search-clear:hover,
+.search-clear:focus-visible {
+    color: #0f7a42;
+}
+
+.search-clear.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.table-wrapper {
+    max-height: min(420px, 60vh);
+    overflow: auto;
+    border-radius: 18px;
+    border: 1px solid #e3e8f3;
+}
+
+.table-wrapper::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+.table-wrapper::-webkit-scrollbar-thumb {
+    background: #bfc7da;
+    border-radius: 999px;
+}
+
+.table-wrapper::-webkit-scrollbar-track {
+    background: transparent;
+}
+
 .feature-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -324,101 +510,83 @@ footer {
     }
 }
 .styled-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 25px 0;
-  font-size: 18px;
-  text-align: left;
-}
-.styled-table thead tr {
-  background-color: #009879;
-  color: #ffffff;
-  text-align: left;
-}
-.styled-table th, .styled-table td {
-  padding: 12px 15px;
-}
-.styled-table tbody tr {
-  border-bottom: 1px solid #dddddd;
-}
-.styled-table tbody tr:nth-of-type(even) {
-  background-color: #f3f3f3;
-}
-.styled-table tbody tr:last-of-type {
-  border-bottom: 2px solid #009879;
-}
-#searchInput {
-    width: 100%;
-    padding: 10px;
-    margin: 10px 0;
-    box-sizing: border-box;
-    border: 2px solid #ccc;
-    border-radius: 4px;
-    font-size: 16px;
-  }
-  #searchInput:focus {
-    border-color: #66afe9;
-    outline: none;
-  }
-/* Основные стили для таблицы */
-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-th, td {
-  padding: 8px;
-  text-align: left;
-  border: 1px solid #ddd;
-}
-
-/* Стили для мобильных устройств */
-@media screen and (max-width: 600px) {
-  table {
-    display: block;
-    overflow-x: auto;
-    white-space: nowrap;
-  }
-
-  thead {
-    display: none;
-  }
-
-  tr {
-    display: block;
-    margin-bottom: 10px;
-  }
-
-  td {
-    display: block;
-    text-align: right;
-    border: none;
-    position: relative;
-    padding-left: 50%;
-  }
-
-  td::before {
-    content: attr(data-label);
-    position: absolute;
-    left: 0;
-    width: 50%;
-    padding-left: 15px;
-    font-weight: bold;
-    text-align: left;
-  }
-}
-table {
     width: 100%;
     border-collapse: collapse;
-  }
-  th, td {
-    padding: 10px;
-    border: 1px solid #ddd;
-    text-align: left;
-  }
-  thead th {
+    font-size: 0.95rem;
+    color: #1f2a44;
+}
+
+.styled-table thead th {
     position: sticky;
     top: 0;
-    background-color: #373838;
-    z-index: 1;
-  }
+    background-color: #0d324d;
+    color: #fff;
+    z-index: 2;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+}
+
+.styled-table th,
+.styled-table td {
+    padding: 0.85rem 1rem;
+}
+
+.styled-table tbody tr {
+    border-bottom: 1px solid #edf2fb;
+    transition: background-color 0.2s ease;
+}
+
+.styled-table tbody tr:nth-of-type(even) {
+    background-color: #fbfdff;
+}
+
+.styled-table tbody tr:hover {
+    background-color: #f1f6ff;
+}
+
+.skeleton-row td {
+    padding: 1rem;
+    position: relative;
+}
+
+.skeleton-row td::after {
+    content: "";
+    display: block;
+    height: 12px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #e8ecf5 25%, #f5f7fc 50%, #e8ecf5 75%);
+    animation: shimmer 1.6s linear infinite;
+}
+
+@keyframes shimmer {
+    0% {
+        background-position: -200px 0;
+    }
+    100% {
+        background-position: 200px 0;
+    }
+}
+
+.table-panel.is-ready .skeleton-row {
+    display: none;
+}
+
+@media screen and (max-width: 600px) {
+    nav {
+        flex-direction: column;
+    }
+
+    .panel-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .table-wrapper {
+        border-radius: 14px;
+    }
+
+    .styled-table thead {
+        font-size: 0.75rem;
+    }
+}


### PR DESCRIPTION
## Summary
- restyle the book list page with a dedicated panel, loading skeletons, and an accessible status indicator
- add a responsive search field, clear button, and refreshed table styling to improve readability across devices
- chunk the spreadsheet rendering, debounce filtering, and update status messaging so large book lists load faster without blocking the UI

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198f209d2c8329b2b655daba782d0b)