### PR TITLE
Add column filters and book detail cards

### DIFF
--- a/book.html
+++ b/book.html
@@ -79,6 +79,10 @@
             <input type="text" id="filter-year" class="column-filter" data-column-filter="4" placeholder="2010" inputmode="numeric" autocomplete="off">
           </label>
           <label class="filter-field">
+            <span>Количество страниц</span>
+            <input type="text" id="filter-pages" class="column-filter" data-column-filter="5" placeholder="Например: 250" inputmode="numeric" autocomplete="off">
+          </label>
+          <label class="filter-field">
             <span>Язык</span>
             <input type="text" id="filter-language" class="column-filter" data-column-filter="6" placeholder="Русский" autocomplete="off">
           </label>
@@ -163,7 +167,7 @@
           </div>
           <p id="card-status" class="card-status">Карточки появятся после загрузки таблицы.</p>
         </div>
-        <div id="book-card-container" class="book-card-grid" data-max-cards="12"></div>
+        <div id="book-card-container" class="book-card-grid" data-max-cards="0"></div>
       </section>
     </section>
   </main>

--- a/book.html
+++ b/book.html
@@ -60,31 +60,31 @@
         <div class="filter-grid">
           <label class="filter-field">
             <span>Название книги</span>
-            <input type="text" id="filter-title" class="column-filter" data-column-filter="0" placeholder="Кардиология" autocomplete="off">
+            <input type="text" id="filter-title" class="column-filter" data-column-filter="0" data-filter-key="title" placeholder="Кардиология" autocomplete="off">
           </label>
           <label class="filter-field">
             <span>Имя автора</span>
-            <input type="text" id="filter-author" class="column-filter" data-column-filter="1" placeholder="Например: Павлов" autocomplete="off">
+            <input type="text" id="filter-author" class="column-filter" data-column-filter="1" data-filter-key="author" placeholder="Например: Павлов" autocomplete="off">
           </label>
           <label class="filter-field">
             <span>Издатель</span>
-            <input type="text" id="filter-publisher" class="column-filter" data-column-filter="2" placeholder="Медицина" autocomplete="off">
+            <input type="text" id="filter-publisher" class="column-filter" data-column-filter="2" data-filter-key="publisher" placeholder="Медицина" autocomplete="off">
           </label>
           <label class="filter-field">
             <span>Город</span>
-            <input type="text" id="filter-city" class="column-filter" data-column-filter="3" placeholder="Москва" autocomplete="off">
+            <input type="text" id="filter-city" class="column-filter" data-column-filter="3" data-filter-key="city" placeholder="Москва" autocomplete="off">
           </label>
           <label class="filter-field">
             <span>Год</span>
-            <input type="text" id="filter-year" class="column-filter" data-column-filter="4" placeholder="2010" inputmode="numeric" autocomplete="off">
+            <input type="text" id="filter-year" class="column-filter" data-column-filter="4" data-filter-key="year" placeholder="2010" inputmode="numeric" autocomplete="off">
           </label>
           <label class="filter-field">
             <span>Количество страниц</span>
-            <input type="text" id="filter-pages" class="column-filter" data-column-filter="5" placeholder="Например: 250" inputmode="numeric" autocomplete="off">
+            <input type="text" id="filter-pages" class="column-filter" data-column-filter="5" data-filter-key="pages" placeholder="Например: 250" inputmode="numeric" autocomplete="off">
           </label>
           <label class="filter-field">
             <span>Язык</span>
-            <input type="text" id="filter-language" class="column-filter" data-column-filter="6" placeholder="Русский" autocomplete="off">
+            <input type="text" id="filter-language" class="column-filter" data-column-filter="6" data-filter-key="language" placeholder="Русский" autocomplete="off">
           </label>
         </div>
       </section>

--- a/book.html
+++ b/book.html
@@ -8,19 +8,8 @@
     <meta name="author" content="Maksat Döwletow">
     <title>Медицинская электронная библиотека — список книг</title>
     <link rel="stylesheet" href="styles.css">
-    <style>
-        table tr:hover {
-            background-color: #f1f1f1;
-        }
-        table tr:nth-child(even) {
-            background-color: #a5aa95;
-        }
-        table tr:nth-child(odd) {
-            background-color: #fff;
-        }
-    </style>
 </head>
-<body>
+<body class="book-page">
   <header>
     <select id="language-select">
       <option value="tm">Türkmençe</option>
@@ -43,25 +32,141 @@
     <a href="book.html" data-lang="tm" class="lang">Kitaplar</a>
     <a href="https://sites.google.com/view/lukmanylyksanlykitaphanasy/ba%C5%9F-sahypa" target="_blank" class="external-link" style="color: blue; font-weight: bold;">Другой сайт библиотеки</a>
   </nav>
-  <section class="search" aria-label="Поиск по книгам">
-      <input type="text" id="searchInput" placeholder="Gözleg..." aria-label="Поиск по названию или автору">
-  </section>
-  <div style="height: 300px; overflow-y: auto;">
-    <table id="book-table" class="styled-table">
-      <thead>
-        <tr>
-          <th>Название книги</th>
-          <th>Имя автора</th>
-          <th>Издатель</th>
-          <th>Город публикации</th>
-          <th>Год публикации</th>
-          <th>Количество страниц</th>
-          <th>Язык книги</th>
-        </tr>
-      </thead>
-      <tbody></tbody>
-    </table>
-  </div>
+  <main class="page-container" aria-label="Каталог книг">
+    <section class="table-panel">
+      <div class="panel-header">
+        <div>
+          <p data-lang="ru" class="lang panel-subtitle">Быстрый поиск по каталогу библиотеки</p>
+          <p data-lang="en" class="lang panel-subtitle">Quick search across the library catalogue</p>
+          <p data-lang="tm" class="lang panel-subtitle">Kitaphana katalogy boýunça çalt gözleg</p>
+        </div>
+        <p id="book-status" class="table-status" role="status" aria-live="polite">Загружаем каталог...</p>
+      </div>
+      <section class="search" aria-label="Поиск по книгам">
+        <label for="searchInput" class="visually-hidden">Поиск по названию или автору</label>
+        <div class="search-field">
+          <input type="text" id="searchInput" placeholder="Gözleg..." autocomplete="off">
+          <button type="button" id="clear-search" class="search-clear" aria-label="Очистить поиск">&times;</button>
+        </div>
+      </section>
+      <section class="filter-panel" aria-label="Расширенный поиск">
+        <div class="filter-panel__header">
+          <div>
+            <p class="detail-tag">Фильтр по столбцам</p>
+            <h2>Отберите книги по любому параметру</h2>
+          </div>
+          <button type="button" id="reset-filters" class="ghost-button">Сбросить фильтры</button>
+        </div>
+        <div class="filter-grid">
+          <label class="filter-field">
+            <span>Название книги</span>
+            <input type="text" id="filter-title" class="column-filter" data-column-filter="0" placeholder="Кардиология" autocomplete="off">
+          </label>
+          <label class="filter-field">
+            <span>Имя автора</span>
+            <input type="text" id="filter-author" class="column-filter" data-column-filter="1" placeholder="Например: Павлов" autocomplete="off">
+          </label>
+          <label class="filter-field">
+            <span>Издатель</span>
+            <input type="text" id="filter-publisher" class="column-filter" data-column-filter="2" placeholder="Медицина" autocomplete="off">
+          </label>
+          <label class="filter-field">
+            <span>Город</span>
+            <input type="text" id="filter-city" class="column-filter" data-column-filter="3" placeholder="Москва" autocomplete="off">
+          </label>
+          <label class="filter-field">
+            <span>Год</span>
+            <input type="text" id="filter-year" class="column-filter" data-column-filter="4" placeholder="2010" inputmode="numeric" autocomplete="off">
+          </label>
+          <label class="filter-field">
+            <span>Язык</span>
+            <input type="text" id="filter-language" class="column-filter" data-column-filter="6" placeholder="Русский" autocomplete="off">
+          </label>
+        </div>
+      </section>
+      <div class="table-wrapper" role="region" aria-live="polite">
+        <table id="book-table" class="styled-table">
+          <thead>
+            <tr>
+              <th>Название книги</th>
+              <th>Имя автора</th>
+              <th>Издатель</th>
+              <th>Город публикации</th>
+              <th>Год публикации</th>
+              <th>Количество страниц</th>
+              <th>Язык книги</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr class="skeleton-row" aria-hidden="true">
+              <td colspan="7"></td>
+            </tr>
+            <tr class="skeleton-row" aria-hidden="true">
+              <td colspan="7"></td>
+            </tr>
+            <tr class="skeleton-row" aria-hidden="true">
+              <td colspan="7"></td>
+            </tr>
+            <tr class="skeleton-row" aria-hidden="true">
+              <td colspan="7"></td>
+            </tr>
+            <tr class="skeleton-row" aria-hidden="true">
+              <td colspan="7"></td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+      <section class="detail-panel" id="book-detail" aria-live="polite">
+        <div class="detail-header">
+          <div>
+            <p class="detail-tag">Карточка книги</p>
+            <h2 class="detail-title">Выберите книгу</h2>
+          </div>
+          <p class="detail-empty">Кликните по строке таблицы или примените фильтры, чтобы увидеть подробности.</p>
+        </div>
+        <dl class="detail-content" hidden>
+          <div>
+            <dt>Название</dt>
+            <dd data-detail-field="title">—</dd>
+          </div>
+          <div>
+            <dt>Автор</dt>
+            <dd data-detail-field="author">—</dd>
+          </div>
+          <div>
+            <dt>Издатель</dt>
+            <dd data-detail-field="publisher">—</dd>
+          </div>
+          <div>
+            <dt>Город</dt>
+            <dd data-detail-field="city">—</dd>
+          </div>
+          <div>
+            <dt>Год</dt>
+            <dd data-detail-field="year">—</dd>
+          </div>
+          <div>
+            <dt>Страниц</dt>
+            <dd data-detail-field="pages">—</dd>
+          </div>
+          <div>
+            <dt>Язык</dt>
+            <dd data-detail-field="language">—</dd>
+          </div>
+        </dl>
+      </section>
+      <section class="card-panel" aria-live="polite">
+        <div class="cards-header">
+          <div>
+            <p class="detail-tag">Найденные книги</p>
+            <h2>Карточки результатов</h2>
+          </div>
+          <p id="card-status" class="card-status">Карточки появятся после загрузки таблицы.</p>
+        </div>
+        <div id="book-card-container" class="book-card-grid" data-max-cards="12"></div>
+      </section>
+    </section>
+  </main>
   <footer>
     <div class="footer-container">
       <div class="contact-info">

--- a/scripts.js
+++ b/scripts.js
@@ -698,25 +698,30 @@ function renderBookCards(rows) {
   const visibleRows = rows.filter(
     (row) => !row.hidden && !row.classList.contains("skeleton-row")
   );
-  const maxCards = Number(cardContainer.dataset.maxCards) || 12;
+  const maxCardsAttr = Number(cardContainer.dataset.maxCards || 0);
+  const shouldLimit = Number.isFinite(maxCardsAttr) && maxCardsAttr > 0;
 
   if (!visibleRows.length) {
     cardContainer.innerHTML = "";
     if (cardStatus) {
-      cardStatus.textContent = "Карточки появятся после выбора книги";
+      cardStatus.textContent = "Подходящих книг не найдено. Попробуйте изменить фильтры.";
     }
     return;
   }
 
   const fragment = document.createDocumentFragment();
-  const cardsToRender = Math.min(visibleRows.length, maxCards);
+  const cardsToRender = shouldLimit
+    ? Math.min(visibleRows.length, maxCardsAttr)
+    : visibleRows.length;
   for (let i = 0; i < cardsToRender; i += 1) {
     fragment.appendChild(createBookCard(getRowDetail(visibleRows[i])));
   }
   cardContainer.innerHTML = "";
   cardContainer.appendChild(fragment);
   if (cardStatus) {
-    cardStatus.textContent = `Показаны ${cardsToRender} из ${visibleRows.length} найденных книг`;
+    cardStatus.textContent = shouldLimit
+      ? `Показаны ${cardsToRender} из ${visibleRows.length} найденных книг`
+      : `Найдено ${visibleRows.length} книг`;
   }
 }
 

--- a/styles.css
+++ b/styles.css
@@ -17,6 +17,48 @@ body {
     background-color: #f4f4f4;
 }
 
+body.book-page {
+    background: linear-gradient(135deg, #eff2f7 0%, #ffffff 55%, #f7fbff 100%);
+    min-height: 100vh;
+}
+
+.book-page header {
+    background: linear-gradient(135deg, #0d324d, #7f5a83);
+    color: #fff;
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+    text-align: left;
+}
+
+.book-page header h1 {
+    margin: 0;
+}
+
+#language-select {
+    border-radius: 999px;
+    border: none;
+    padding: 0.45rem 1.5rem;
+    font-weight: 600;
+    background: rgba(255, 255, 255, 0.18);
+    color: #fff;
+    backdrop-filter: blur(6px);
+    cursor: pointer;
+}
+
+#language-select option {
+    color: #111;
+}
+
+@media (min-width: 768px) {
+    .book-page header {
+        justify-content: space-between;
+        padding-inline: 3rem;
+    }
+}
+
 #auth {
     max-width: 360px;
     margin: 1rem auto;
@@ -184,6 +226,352 @@ nav a:hover {
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
+.page-container {
+    padding: clamp(1rem, 4vw, 2.5rem);
+    max-width: 1200px;
+    margin: 0 auto 3rem;
+}
+
+.table-panel {
+    background: #fff;
+    border-radius: 24px;
+    padding: clamp(1rem, 4vw, 2.5rem);
+    box-shadow: 0 25px 60px rgba(15, 28, 63, 0.12);
+    border: 1px solid #eef1f5;
+}
+
+.detail-tag {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: #7f5a83;
+    margin: 0 0 0.25rem;
+}
+
+.ghost-button {
+    border-radius: 999px;
+    border: 1px solid #c7cedd;
+    background: transparent;
+    color: #4a4f63;
+    padding: 0.4rem 1.25rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: background-color var(--transition), color var(--transition), border-color var(--transition);
+}
+
+.ghost-button:hover,
+.ghost-button:focus-visible {
+    border-color: #7f5a83;
+    color: #7f5a83;
+    background: rgba(127, 90, 131, 0.08);
+}
+
+.card-status {
+    margin: 0;
+    color: #475467;
+    font-weight: 500;
+}
+
+.panel-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 1.25rem;
+}
+
+.panel-subtitle {
+    margin: 0;
+    color: #4a4f63;
+    font-weight: 500;
+}
+
+.table-status {
+    margin: 0;
+    font-weight: 600;
+    color: #4a5568;
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    background: #f1f5f9;
+}
+
+.table-status[data-state="pending"] {
+    color: #b7791f;
+    background: #fff8eb;
+}
+
+.table-status[data-state="error"] {
+    color: #c53030;
+    background: #ffe5e5;
+}
+
+.table-status[data-state="success"] {
+    color: #0f7a42;
+    background: #e6f6ee;
+}
+
+.table-panel.is-loading .table-status::after {
+    content: "";
+    margin-left: 0.5rem;
+    width: 0.85rem;
+    height: 0.85rem;
+    border: 2px solid currentColor;
+    border-bottom-color: transparent;
+    border-radius: 50%;
+    display: inline-block;
+    animation: spin 0.6s linear infinite;
+    vertical-align: middle;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.search {
+    margin-bottom: 1rem;
+}
+
+.search-field {
+    position: relative;
+}
+
+.filter-panel {
+    border: 1px solid #e4e9f7;
+    border-radius: 20px;
+    padding: 1.25rem;
+    margin-bottom: 1.5rem;
+    background: linear-gradient(135deg, #f9fbff 0%, #ffffff 100%);
+    box-shadow: 0 15px 35px rgba(15, 28, 63, 0.08);
+}
+
+.filter-panel__header {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin-bottom: 1rem;
+}
+
+.filter-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+}
+
+.filter-field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.4rem;
+    font-size: 0.85rem;
+    color: #475467;
+}
+
+.column-filter {
+    border-radius: 12px;
+    border: 1px solid #dbe2f0;
+    padding: 0.65rem 0.85rem;
+    background: #fff;
+    transition: border-color var(--transition), box-shadow var(--transition);
+}
+
+.column-filter:focus {
+    outline: none;
+    border-color: #7f5a83;
+    box-shadow: 0 0 0 2px rgba(127, 90, 131, 0.2);
+}
+
+#searchInput {
+    width: 100%;
+    padding: 0.85rem 2.5rem 0.85rem 1rem;
+    border-radius: 14px;
+    border: 1px solid #dbe2f0;
+    font-size: 1rem;
+    background: #f6f8fc;
+    transition: border-color var(--transition), box-shadow var(--transition);
+    box-sizing: border-box;
+}
+
+#searchInput:focus {
+    border-color: #7f5a83;
+    box-shadow: 0 0 0 3px rgba(127, 90, 131, 0.2);
+    outline: none;
+}
+
+.search-clear {
+    position: absolute;
+    right: 0.4rem;
+    top: 50%;
+    transform: translateY(-50%);
+    border: none;
+    background: transparent;
+    font-size: 1.25rem;
+    cursor: pointer;
+    color: #7f8ba3;
+    padding: 0.25rem 0.75rem;
+    opacity: 0;
+    pointer-events: none;
+    transition: color var(--transition), opacity var(--transition);
+}
+
+.search-clear:hover,
+.search-clear:focus-visible {
+    color: #0f7a42;
+}
+
+.search-clear.is-visible {
+    opacity: 1;
+    pointer-events: auto;
+}
+
+.table-wrapper {
+    max-height: min(420px, 60vh);
+    overflow: auto;
+    border-radius: 18px;
+    border: 1px solid #e3e8f3;
+}
+
+.detail-panel,
+.card-panel {
+    margin-top: 1.5rem;
+    border-radius: 22px;
+    border: 1px solid #e3e6ec;
+    background: linear-gradient(135deg, #ffffff, #f7f9ff);
+    padding: clamp(1rem, 4vw, 2rem);
+    box-shadow: 0 20px 50px rgba(20, 26, 56, 0.1);
+}
+
+.detail-header,
+.cards-header {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+    gap: 0.75rem;
+    align-items: baseline;
+}
+
+.detail-title {
+    margin: 0;
+}
+
+.detail-empty {
+    margin: 0;
+    color: #6b7280;
+    max-width: 460px;
+}
+
+.detail-panel.has-data {
+    border-color: #c0e0d4;
+    box-shadow: 0 25px 55px rgba(15, 90, 70, 0.12);
+}
+
+.detail-content {
+    margin-top: 1.25rem;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1rem;
+}
+
+.detail-content div {
+    background: #fff;
+    border-radius: 16px;
+    padding: 0.75rem 1rem;
+    border: 1px solid #eef2f8;
+}
+
+.detail-content dt {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #7c8194;
+    margin-bottom: 0.25rem;
+}
+
+.detail-content dd {
+    margin: 0;
+    font-size: 1rem;
+    font-weight: 600;
+    color: #101828;
+}
+
+.cards-header h2 {
+    margin: 0;
+}
+
+.book-card-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+    gap: 1rem;
+    margin-top: 1.25rem;
+}
+
+.book-card {
+    border-radius: 20px;
+    padding: 1.25rem;
+    background: linear-gradient(160deg, #ffffff 0%, #f8fbff 100%);
+    border: 1px solid #e6ecf5;
+    box-shadow: 0 12px 30px rgba(15, 28, 63, 0.08);
+    display: flex;
+    flex-direction: column;
+    gap: 0.65rem;
+}
+
+.book-card h3 {
+    margin: 0;
+    font-size: 1.1rem;
+    color: #172554;
+}
+
+.book-card__meta {
+    margin: 0;
+    font-size: 0.9rem;
+    color: #475467;
+}
+
+.book-card__details {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+}
+
+.book-card__details li {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    flex-wrap: wrap;
+    font-size: 0.85rem;
+    color: #4a4f63;
+}
+
+.book-card__details span {
+    color: #8c90a3;
+}
+
+.book-card__details strong {
+    font-weight: 600;
+    color: #0f172a;
+}
+
+.table-wrapper::-webkit-scrollbar {
+    width: 8px;
+    height: 8px;
+}
+
+.table-wrapper::-webkit-scrollbar-thumb {
+    background: #bfc7da;
+    border-radius: 999px;
+}
+
+.table-wrapper::-webkit-scrollbar-track {
+    background: transparent;
+}
+
 .feature-grid {
     display: grid;
     grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
@@ -324,101 +712,98 @@ footer {
     }
 }
 .styled-table {
-  width: 100%;
-  border-collapse: collapse;
-  margin: 25px 0;
-  font-size: 18px;
-  text-align: left;
-}
-.styled-table thead tr {
-  background-color: #009879;
-  color: #ffffff;
-  text-align: left;
-}
-.styled-table th, .styled-table td {
-  padding: 12px 15px;
-}
-.styled-table tbody tr {
-  border-bottom: 1px solid #dddddd;
-}
-.styled-table tbody tr:nth-of-type(even) {
-  background-color: #f3f3f3;
-}
-.styled-table tbody tr:last-of-type {
-  border-bottom: 2px solid #009879;
-}
-#searchInput {
-    width: 100%;
-    padding: 10px;
-    margin: 10px 0;
-    box-sizing: border-box;
-    border: 2px solid #ccc;
-    border-radius: 4px;
-    font-size: 16px;
-  }
-  #searchInput:focus {
-    border-color: #66afe9;
-    outline: none;
-  }
-/* Основные стили для таблицы */
-table {
-  width: 100%;
-  border-collapse: collapse;
-}
-
-th, td {
-  padding: 8px;
-  text-align: left;
-  border: 1px solid #ddd;
-}
-
-/* Стили для мобильных устройств */
-@media screen and (max-width: 600px) {
-  table {
-    display: block;
-    overflow-x: auto;
-    white-space: nowrap;
-  }
-
-  thead {
-    display: none;
-  }
-
-  tr {
-    display: block;
-    margin-bottom: 10px;
-  }
-
-  td {
-    display: block;
-    text-align: right;
-    border: none;
-    position: relative;
-    padding-left: 50%;
-  }
-
-  td::before {
-    content: attr(data-label);
-    position: absolute;
-    left: 0;
-    width: 50%;
-    padding-left: 15px;
-    font-weight: bold;
-    text-align: left;
-  }
-}
-table {
     width: 100%;
     border-collapse: collapse;
-  }
-  th, td {
-    padding: 10px;
-    border: 1px solid #ddd;
-    text-align: left;
-  }
-  thead th {
+    font-size: 0.95rem;
+    color: #1f2a44;
+}
+
+.styled-table thead th {
     position: sticky;
     top: 0;
-    background-color: #373838;
-    z-index: 1;
-  }
+    background-color: #0d324d;
+    color: #fff;
+    z-index: 2;
+    letter-spacing: 0.03em;
+    text-transform: uppercase;
+    font-size: 0.8rem;
+}
+
+.styled-table th,
+.styled-table td {
+    padding: 0.85rem 1rem;
+}
+
+.styled-table tbody tr {
+    border-bottom: 1px solid #edf2fb;
+    transition: background-color 0.2s ease;
+}
+
+.styled-table tbody tr:nth-of-type(even) {
+    background-color: #fbfdff;
+}
+
+.styled-table tbody tr:hover {
+    background-color: #f1f6ff;
+}
+
+.styled-table tbody tr.is-selected {
+    background: linear-gradient(90deg, rgba(127, 90, 131, 0.1), rgba(15, 28, 63, 0.05));
+    box-shadow: inset 0 0 0 1px rgba(127, 90, 131, 0.3);
+}
+
+.skeleton-row td {
+    padding: 1rem;
+    position: relative;
+}
+
+.skeleton-row td::after {
+    content: "";
+    display: block;
+    height: 12px;
+    border-radius: 999px;
+    background: linear-gradient(90deg, #e8ecf5 25%, #f5f7fc 50%, #e8ecf5 75%);
+    animation: shimmer 1.6s linear infinite;
+}
+
+@keyframes shimmer {
+    0% {
+        background-position: -200px 0;
+    }
+    100% {
+        background-position: 200px 0;
+    }
+}
+
+.table-panel.is-ready .skeleton-row {
+    display: none;
+}
+
+@media screen and (max-width: 600px) {
+    nav {
+        flex-direction: column;
+    }
+
+    .panel-header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .filter-panel__header {
+        flex-direction: column;
+        align-items: flex-start;
+    }
+
+    .table-wrapper {
+        border-radius: 14px;
+    }
+
+    .styled-table thead {
+        font-size: 0.75rem;
+    }
+
+    .detail-panel,
+    .card-panel {
+        padding: 1rem;
+    }
+}

--- a/styles.css
+++ b/styles.css
@@ -503,26 +503,46 @@ nav a:hover {
 
 .book-card-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-    gap: 1rem;
+    grid-template-columns: repeat(auto-fit, minmax(250px, 1fr));
+    gap: 1.25rem;
     margin-top: 1.25rem;
 }
 
 .book-card {
-    border-radius: 20px;
-    padding: 1.25rem;
-    background: linear-gradient(160deg, #ffffff 0%, #f8fbff 100%);
-    border: 1px solid #e6ecf5;
-    box-shadow: 0 12px 30px rgba(15, 28, 63, 0.08);
+    position: relative;
+    border-radius: 24px;
+    padding: 1.5rem;
+    background: radial-gradient(circle at 0% 0%, rgba(0, 152, 121, 0.12), transparent 65%),
+        linear-gradient(165deg, #ffffff 0%, #f5fbff 50%, #eef6ff 100%);
+    border: 1px solid rgba(0, 0, 0, 0.04);
+    box-shadow: 0 20px 35px rgba(4, 23, 45, 0.08);
     display: flex;
     flex-direction: column;
-    gap: 0.65rem;
+    gap: 0.85rem;
+    min-height: 260px;
+}
+
+.book-card__badge {
+    position: absolute;
+    top: 1rem;
+    right: 1.25rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 40px;
+    height: 40px;
+    border-radius: 14px;
+    background: rgba(0, 152, 121, 0.12);
+    color: #047857;
+    font-weight: 700;
+    font-size: 0.95rem;
 }
 
 .book-card h3 {
     margin: 0;
-    font-size: 1.1rem;
-    color: #172554;
+    font-size: 1.2rem;
+    color: #0f172a;
+    padding-right: 3.5rem;
 }
 
 .book-card__meta {
@@ -531,30 +551,52 @@ nav a:hover {
     color: #475467;
 }
 
-.book-card__details {
-    list-style: none;
-    padding: 0;
-    margin: 0;
+.book-card__chips {
     display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
-}
-
-.book-card__details li {
-    display: flex;
-    justify-content: space-between;
-    gap: 0.5rem;
     flex-wrap: wrap;
-    font-size: 0.85rem;
-    color: #4a4f63;
+    gap: 0.5rem;
 }
 
-.book-card__details span {
-    color: #8c90a3;
-}
-
-.book-card__details strong {
+.book-card__chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    padding: 0.4rem 0.85rem;
+    border-radius: 999px;
+    background: rgba(15, 76, 129, 0.08);
+    color: #0f4c81;
     font-weight: 600;
+}
+
+.book-card__details {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+    gap: 0.75rem;
+    margin: 0;
+}
+
+.book-card__details div {
+    padding: 0.75rem 0.9rem;
+    border-radius: 16px;
+    background: #fff;
+    border: 1px solid #edf1f7;
+}
+
+.book-card__details dt {
+    margin: 0;
+    font-size: 0.7rem;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: #7c8299;
+}
+
+.book-card__details dd {
+    margin: 0.15rem 0 0;
+    font-weight: 600;
+    font-size: 0.95rem;
     color: #0f172a;
 }
 


### PR DESCRIPTION
## Summary
- add a column filter strip, detailed book drawer, and card grid to the book list page so matches are highlighted individually with refreshed styling
- extend the book-table script with per-column filtering, row selection, detail rendering, and lightweight card generation alongside debounced search handling
- layer in the supporting styles for the new filters, detail drawer, selection state, and responsive result cards

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69198f209d2c8329b2b655daba782d0b)