### PR TITLE
Sync language selector with page language

### DIFF
--- a/BookCategory.html
+++ b/BookCategory.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="ru" data-lang="ru">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/auth.html
+++ b/auth.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="ru" data-lang="ru">
 <head>
     <meta charset="UTF-8">
     <title>Регистрация и Вход</title>

--- a/book.html
+++ b/book.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="ru" data-lang="ru">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/books2.html
+++ b/books2.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="ru" data-lang="ru">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/scripts.js
+++ b/scripts.js
@@ -123,8 +123,16 @@ function initLanguageSwitcher() {
     return;
   }
 
+  const documentLang = document.documentElement.dataset.lang || document.documentElement.lang;
+  if (documentLang && languageSelect.value !== documentLang) {
+    const optionExists = Array.from(languageSelect.options).some((option) => option.value === documentLang);
+    if (optionExists) {
+      languageSelect.value = documentLang;
+    }
+  }
+
   const changeLanguage = () => {
-    const lang = languageSelect.value || "ru";
+    const lang = languageSelect.value || documentLang || "ru";
     document.documentElement.dataset.lang = lang;
     document.documentElement.lang = lang;
     document.querySelectorAll(".lang").forEach((element) => {

--- a/styles.css
+++ b/styles.css
@@ -588,8 +588,10 @@ footer {
     display: none;
 }
 
-.lang[data-lang="ru"] {
-    display: block;
+:root[data-lang="ru"] .lang[data-lang="ru"],
+:root[data-lang="en"] .lang[data-lang="en"],
+:root[data-lang="tm"] .lang[data-lang="tm"] {
+    display: initial;
 }
 
 .highlight {


### PR DESCRIPTION
## Summary
- initialize the language dropdown with the page's current locale so it no longer forces an unintended language on load
- fall back to the existing dropdown value when the page language is unavailable

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919a5cc102483298d3720c3e9bed0fd)