### PR TITLE
Revamp book catalog page with card layout and filters

### DIFF
--- a/book.html
+++ b/book.html
@@ -1,278 +1,836 @@
 <!DOCTYPE html>
 <html lang="ru" data-lang="ru">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="Lukmançylyk kitaphanasy - 1000-den gowrak kitaplara oflayn elýeterlik. Kitaplary gözlemek we kategoriýalar boýunça seretmek mümkinçiligi.">
-    <meta name="keywords" content="lukmançylyk, kitaplar, kategoriýalar, oflayn, bilim, Медицинская электронная библиотека">
-    <meta name="author" content="Maksat Döwletow">
-    <title>Медицинская электронная библиотека — список книг</title>
-    <link rel="stylesheet" href="styles.css">
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Медицинская электронная библиотека — книги</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+  <style>
+    :root {
+      color-scheme: light;
+      --bg: #f5f6fb;
+      --card-bg: #ffffff;
+      --primary: #0b6efd;
+      --primary-dark: #084298;
+      --text: #1f2a37;
+      --muted: #5f6b7c;
+      --border: #d9e0ec;
+      --shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
+      --chip-bg: #e7f1ff;
+      --chip-text: #1c4ed8;
+      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+    }
+
+    * {
+      box-sizing: border-box;
+    }
+
+    body {
+      margin: 0;
+      min-height: 100vh;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+    }
+
+    a {
+      color: var(--primary);
+      text-decoration: none;
+    }
+
+    .site-header {
+      background: var(--card-bg);
+      padding: 1.5rem clamp(1rem, 4vw, 4rem);
+      display: flex;
+      flex-wrap: wrap;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      box-shadow: 0 1px 0 rgba(15, 23, 42, 0.08);
+      position: sticky;
+      top: 0;
+      z-index: 10;
+    }
+
+    .logo-area {
+      display: flex;
+      flex-direction: column;
+      gap: 0.2rem;
+    }
+
+    .logo-area__eyebrow {
+      font-size: 0.9rem;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--muted);
+    }
+
+    .logo-area__title {
+      font-size: clamp(1.5rem, 2vw, 2rem);
+      margin: 0;
+    }
+
+    .language-switcher {
+      display: flex;
+      align-items: center;
+      gap: 0.5rem;
+      font-weight: 500;
+    }
+
+    select {
+      border-radius: 999px;
+      border: 1px solid var(--border);
+      padding: 0.4rem 1.2rem;
+      font-size: 1rem;
+      font-family: inherit;
+      background: #fff;
+      color: var(--text);
+      transition: border-color 0.2s ease, box-shadow 0.2s ease;
+    }
+
+    select:focus-visible, input:focus-visible {
+      outline: none;
+      border-color: var(--primary);
+      box-shadow: 0 0 0 3px rgba(11, 110, 253, 0.15);
+    }
+
+    nav {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 1rem;
+      padding: 0.75rem clamp(1rem, 4vw, 4rem);
+      background: transparent;
+    }
+
+    nav a {
+      font-weight: 500;
+      color: var(--muted);
+      padding: 0.25rem 0.5rem;
+      border-radius: 999px;
+      transition: color 0.2s ease, background 0.2s ease;
+    }
+
+    nav a:hover,
+    nav a:focus-visible {
+      color: var(--primary);
+      background: rgba(11, 110, 253, 0.08);
+    }
+
+    main {
+      padding: 2rem clamp(1rem, 4vw, 4rem) 4rem;
+      display: flex;
+      flex-direction: column;
+      gap: 2rem;
+    }
+
+    .filter-panel {
+      background: var(--card-bg);
+      border-radius: 24px;
+      padding: clamp(1.5rem, 3vw, 2.5rem);
+      box-shadow: var(--shadow);
+    }
+
+    .filter-panel__head {
+      margin-bottom: 1.5rem;
+    }
+
+    .filter-panel__title {
+      margin: 0 0 0.3rem;
+      font-size: clamp(1.5rem, 2vw, 2rem);
+    }
+
+    .filter-panel__subtitle {
+      margin: 0;
+      color: var(--muted);
+    }
+
+    .filter-form {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+      gap: 1rem;
+      align-items: end;
+    }
+
+    .filter-field {
+      display: flex;
+      flex-direction: column;
+      gap: 0.35rem;
+      font-weight: 500;
+      color: var(--muted);
+    }
+
+    .filter-field input {
+      border-radius: 14px;
+      border: 1px solid var(--border);
+      padding: 0.85rem 1rem;
+      font-size: 1rem;
+      font-family: inherit;
+      transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
+      background: #fdfdff;
+    }
+
+    .filter-field input:hover {
+      transform: translateY(-1px);
+      border-color: var(--primary);
+    }
+
+    .filter-actions {
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+      margin-top: 0.5rem;
+    }
+
+    .button {
+      border: none;
+      border-radius: 14px;
+      padding: 0.85rem 1.5rem;
+      font-size: 1rem;
+      font-weight: 600;
+      font-family: inherit;
+      cursor: pointer;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+    }
+
+    .button--primary {
+      background: var(--primary);
+      color: #fff;
+      box-shadow: 0 12px 20px rgba(11, 110, 253, 0.25);
+    }
+
+    .button--primary:hover {
+      transform: translateY(-2px);
+      background: var(--primary-dark);
+    }
+
+    .button--ghost {
+      background: rgba(15, 23, 42, 0.06);
+      color: var(--text);
+    }
+
+    .status-bar {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      gap: 1rem;
+      flex-wrap: wrap;
+    }
+
+    .status-pill {
+      background: var(--card-bg);
+      border-radius: 999px;
+      padding: 0.35rem 0.95rem;
+      color: var(--muted);
+      font-weight: 500;
+      box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
+    }
+
+    .book-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 1.5rem;
+    }
+
+    .book-card {
+      background: var(--card-bg);
+      border-radius: 24px;
+      padding: 1.5rem;
+      box-shadow: var(--shadow);
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+      transition: transform 0.25s ease, box-shadow 0.25s ease;
+      min-height: 280px;
+    }
+
+    .book-card:hover {
+      transform: translateY(-6px) scale(1.01);
+      box-shadow: 0 20px 35px rgba(15, 23, 42, 0.15);
+    }
+
+    .book-card__top {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 0.5rem;
+      flex-wrap: wrap;
+    }
+
+    .book-card__chip {
+      background: var(--chip-bg);
+      color: var(--chip-text);
+      padding: 0.2rem 0.85rem;
+      border-radius: 999px;
+      font-size: 0.85rem;
+      font-weight: 600;
+    }
+
+    .book-card__title {
+      margin: 0;
+      font-size: 1.15rem;
+      line-height: 1.4;
+    }
+
+    .book-card__author {
+      margin: 0;
+      color: var(--muted);
+      font-size: 0.95rem;
+    }
+
+    .book-card__details {
+      display: grid;
+      grid-template-columns: repeat(2, minmax(0, 1fr));
+      gap: 0.65rem 1rem;
+      font-size: 0.9rem;
+    }
+
+    .book-card__label {
+      color: var(--muted);
+      font-size: 0.8rem;
+      text-transform: uppercase;
+      letter-spacing: 0.08em;
+      display: block;
+    }
+
+    .book-card__actions {
+      margin-top: auto;
+      display: flex;
+      gap: 0.75rem;
+      flex-wrap: wrap;
+    }
+
+    .book-card__link {
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      gap: 0.4rem;
+      border-radius: 14px;
+      padding: 0.7rem 1.2rem;
+      font-weight: 600;
+      background: var(--primary);
+      color: #fff;
+      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+      flex: 1;
+      min-width: 160px;
+    }
+
+    .book-card__link:hover {
+      transform: translateY(-2px);
+      background: var(--primary-dark);
+      box-shadow: 0 15px 20px rgba(11, 110, 253, 0.2);
+    }
+
+    .book-card__link[aria-disabled="true"] {
+      cursor: not-allowed;
+      background: rgba(15, 23, 42, 0.12);
+      box-shadow: none;
+    }
+
+    .empty-state {
+      grid-column: 1 / -1;
+      background: rgba(11, 110, 253, 0.08);
+      color: var(--primary-dark);
+      padding: 2rem;
+      border-radius: 24px;
+      text-align: center;
+      font-weight: 600;
+    }
+
+    footer {
+      background: #0f172a;
+      color: rgba(255, 255, 255, 0.8);
+      padding: 2.5rem clamp(1rem, 4vw, 4rem);
+      margin-top: 3rem;
+    }
+
+    .footer-content {
+      display: flex;
+      flex-wrap: wrap;
+      gap: 2rem;
+      justify-content: space-between;
+    }
+
+    .footer-content a {
+      color: #fff;
+      font-weight: 600;
+    }
+
+    @media (max-width: 720px) {
+      .book-card__details {
+        grid-template-columns: 1fr;
+      }
+
+      .site-header {
+        position: static;
+      }
+    }
+  </style>
 </head>
-<body class="book-page">
-  <header>
-    <select id="language-select">
-      <option value="tm">Türkmençe</option>
-      <option value="ru" selected>Русский</option>
-      <option value="en">English</option>
-    </select>
-    <h1 data-lang="ru" class="lang">Список книг</h1>
-    <h1 data-lang="en" class="lang">Book List</h1>
-    <h1 data-lang="tm" class="lang">Kitaplar</h1>
+<body>
+  <header class="site-header">
+    <div class="logo-area">
+      <span class="logo-area__eyebrow" data-i18n="tagline">Медицинская электронная библиотека</span>
+      <h1 class="logo-area__title" data-i18n="heroTitle">Каталог медицинских книг</h1>
+    </div>
+    <div class="language-switcher">
+      <label for="language-select" data-i18n="languageLabel">Язык интерфейса:</label>
+      <select id="language-select" aria-label="Select interface language">
+        <option value="tm">Türkmençe</option>
+        <option value="ru" selected>Русский</option>
+        <option value="en">English</option>
+      </select>
+    </div>
   </header>
-  <nav>
-    <a href="index.html" data-lang="ru" class="lang">Главная</a>
-    <a href="index.html" data-lang="en" class="lang">Home</a>
-    <a href="index.html" data-lang="tm" class="lang">Baş sahypa</a>
-    <a href="BookCategory.html" data-lang="ru" class="lang">Категории книг</a>
-    <a href="BookCategory.html" data-lang="en" class="lang">Book Categories</a>
-    <a href="BookCategory.html" data-lang="tm" class="lang">Kitap kategoriýalary</a>
-    <a href="book.html" data-lang="ru" class="lang">Список книг</a>
-    <a href="book.html" data-lang="en" class="lang">Book List</a>
-    <a href="book.html" data-lang="tm" class="lang">Kitaplar</a>
-    <a href="https://sites.google.com/view/lukmanylyksanlykitaphanasy/ba%C5%9F-sahypa" target="_blank" class="external-link" style="color: blue; font-weight: bold;">Другой сайт библиотеки</a>
+  <nav aria-label="Primary">
+    <a href="index.html" data-i18n="navHome">Главная</a>
+    <a href="BookCategory.html" data-i18n="navCategories">Категории</a>
+    <a href="book.html" aria-current="page" data-i18n="navBooks">Каталог книг</a>
+    <a href="https://sites.google.com/view/lukmanylyksanlykitaphanasy/ba%C5%9F-sahypa" target="_blank" rel="noopener" data-i18n="navAltSite">Другой сайт библиотеки</a>
   </nav>
-  <main class="page-container" aria-label="Каталог книг">
-    <section class="table-panel">
-      <div class="panel-header">
-        <div>
-          <p data-lang="ru" class="lang panel-subtitle">Быстрый поиск по каталогу библиотеки</p>
-          <p data-lang="en" class="lang panel-subtitle">Quick search across the library catalogue</p>
-          <p data-lang="tm" class="lang panel-subtitle">Kitaphana katalogy boýunça çalt gözleg</p>
-        </div>
-        <p
-          id="book-status"
-          class="table-status"
-          role="status"
-          aria-live="polite"
-          data-i18n-key="tableLoading"
-        >
-          Загружаем каталог...
-        </p>
+  <main>
+    <section class="filter-panel" aria-labelledby="filter-title">
+      <div class="filter-panel__head">
+        <p class="logo-area__eyebrow" data-i18n="filterEyebrow">Фильтр книг</p>
+        <h2 id="filter-title" class="filter-panel__title" data-i18n="filterTitle">Найдите нужную литературу</h2>
+        <p class="filter-panel__subtitle" data-i18n="filterSubtitle">Используйте отдельные поля ниже, чтобы быстро отфильтровать книги по названию, автору, году, разделу и языку.</p>
       </div>
-      <section class="search" aria-label="Поиск по книгам">
-        <label for="searchInput" class="visually-hidden">Поиск по названию или автору</label>
-        <div class="search-field">
-          <input
-            type="text"
-            id="searchInput"
-            placeholder="Gözleg..."
-            autocomplete="off"
-            data-placeholder-ru="Поиск..."
-            data-placeholder-en="Search..."
-            data-placeholder-tm="Gözleg..."
-          >
-          <button type="button" id="clear-search" class="search-clear" aria-label="Очистить поиск">&times;</button>
-        </div>
-      </section>
-      <section class="search-filters" aria-label="Фильтры по столбцам">
-        <div class="filter-field">
-          <label for="filter-title">
-            <span data-lang="ru" class="lang">Название книги</span>
-            <span data-lang="en" class="lang">Book title</span>
-            <span data-lang="tm" class="lang">Kitabyň ady</span>
-          </label>
-          <input
-            type="text"
-            id="filter-title"
-            placeholder="Например: терапия"
-            autocomplete="off"
-            data-placeholder-ru="Например: терапия"
-            data-placeholder-en="e.g. therapy"
-            data-placeholder-tm="mysal üçin: terapiýa"
-          >
-        </div>
-        <div class="filter-field">
-          <label for="filter-author">
-            <span data-lang="ru" class="lang">Имя автора</span>
-            <span data-lang="en" class="lang">Author</span>
-            <span data-lang="tm" class="lang">Awtoryň ady</span>
-          </label>
-          <input
-            type="text"
-            id="filter-author"
-            placeholder="Например: Иванов"
-            autocomplete="off"
-            data-placeholder-ru="Например: Иванов"
-            data-placeholder-en="e.g. Ivanov"
-            data-placeholder-tm="mysal üçin: Ivanow"
-          >
-        </div>
-        <div class="filter-field">
-          <label for="filter-publisher">
-            <span data-lang="ru" class="lang">Издатель</span>
-            <span data-lang="en" class="lang">Publisher</span>
-            <span data-lang="tm" class="lang">Neşirçi</span>
-          </label>
-          <input
-            type="text"
-            id="filter-publisher"
-            placeholder="Например: Медицина"
-            autocomplete="off"
-            data-placeholder-ru="Например: Медицина"
-            data-placeholder-en="e.g. Medicine"
-            data-placeholder-tm="mysal üçin: Medisina"
-          >
-        </div>
-        <div class="filter-field">
-          <label for="filter-city">
-            <span data-lang="ru" class="lang">Город публикации</span>
-            <span data-lang="en" class="lang">City</span>
-            <span data-lang="tm" class="lang">Şäher</span>
-          </label>
-          <input
-            type="text"
-            id="filter-city"
-            placeholder="Например: Москва"
-            autocomplete="off"
-            data-placeholder-ru="Например: Москва"
-            data-placeholder-en="e.g. Moscow"
-            data-placeholder-tm="mysal üçin: Moskwa"
-          >
-        </div>
-        <div class="filter-field">
-          <label for="filter-year">
-            <span data-lang="ru" class="lang">Год</span>
-            <span data-lang="en" class="lang">Year</span>
-            <span data-lang="tm" class="lang">Ýyl</span>
-          </label>
-          <input
-            type="text"
-            id="filter-year"
-            inputmode="numeric"
-            placeholder="Например: 2019"
-            autocomplete="off"
-            data-placeholder-ru="Например: 2019"
-            data-placeholder-en="e.g. 2019"
-            data-placeholder-tm="mysal üçin: 2019"
-          >
-        </div>
-        <div class="filter-field">
-          <label for="filter-pages">
-            <span data-lang="ru" class="lang">Количество страниц</span>
-            <span data-lang="en" class="lang">Pages</span>
-            <span data-lang="tm" class="lang">Sahypalar</span>
-          </label>
-          <input
-            type="text"
-            id="filter-pages"
-            inputmode="numeric"
-            placeholder="Например: 320"
-            autocomplete="off"
-            data-placeholder-ru="Например: 320"
-            data-placeholder-en="e.g. 320"
-            data-placeholder-tm="mysal üçin: 320"
-          >
-        </div>
-        <div class="filter-field">
-          <label for="filter-language">
-            <span data-lang="ru" class="lang">Язык книги</span>
-            <span data-lang="en" class="lang">Book language</span>
-            <span data-lang="tm" class="lang">Kitabyň dili</span>
-          </label>
-          <input
-            type="text"
-            id="filter-language"
-            placeholder="Например: Русский"
-            autocomplete="off"
-            data-placeholder-ru="Например: Русский"
-            data-placeholder-en="e.g. Russian"
-            data-placeholder-tm="mysal üçin: Rus dili"
-          >
-        </div>
-      </section>
-      <div class="table-wrapper" role="region" aria-live="polite">
-        <table id="book-table" class="styled-table">
-          <thead>
-            <tr>
-              <th>
-                <span data-lang="ru" class="lang">Название книги</span>
-                <span data-lang="en" class="lang">Book title</span>
-                <span data-lang="tm" class="lang">Kitabyň ady</span>
-              </th>
-              <th>
-                <span data-lang="ru" class="lang">Имя автора</span>
-                <span data-lang="en" class="lang">Author</span>
-                <span data-lang="tm" class="lang">Awtoryň ady</span>
-              </th>
-              <th>
-                <span data-lang="ru" class="lang">Издатель</span>
-                <span data-lang="en" class="lang">Publisher</span>
-                <span data-lang="tm" class="lang">Neşirçi</span>
-              </th>
-              <th>
-                <span data-lang="ru" class="lang">Город публикации</span>
-                <span data-lang="en" class="lang">City</span>
-                <span data-lang="tm" class="lang">Şäher</span>
-              </th>
-              <th>
-                <span data-lang="ru" class="lang">Год публикации</span>
-                <span data-lang="en" class="lang">Year</span>
-                <span data-lang="tm" class="lang">Ýyl</span>
-              </th>
-              <th>
-                <span data-lang="ru" class="lang">Количество страниц</span>
-                <span data-lang="en" class="lang">Pages</span>
-                <span data-lang="tm" class="lang">Sahypalar</span>
-              </th>
-              <th>
-                <span data-lang="ru" class="lang">Язык книги</span>
-                <span data-lang="en" class="lang">Book language</span>
-                <span data-lang="tm" class="lang">Kitabyň dili</span>
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr class="skeleton-row" aria-hidden="true">
-              <td colspan="7"></td>
-            </tr>
-            <tr class="skeleton-row" aria-hidden="true">
-              <td colspan="7"></td>
-            </tr>
-            <tr class="skeleton-row" aria-hidden="true">
-              <td colspan="7"></td>
-            </tr>
-            <tr class="skeleton-row" aria-hidden="true">
-              <td colspan="7"></td>
-            </tr>
-            <tr class="skeleton-row" aria-hidden="true">
-              <td colspan="7"></td>
-            </tr>
-          </tbody>
-        </table>
+      <div class="filter-form" id="filter-form">
+        <label class="filter-field">
+          <span data-i18n="labelTitle">Название книги</span>
+          <input type="text" data-filter="title" data-i18n-placeholder="placeholderTitle" placeholder="Например: нейрохирургия" autocomplete="off">
+        </label>
+        <label class="filter-field">
+          <span data-i18n="labelAuthor">Автор</span>
+          <input type="text" data-filter="author" data-i18n-placeholder="placeholderAuthor" placeholder="Например: Apuzzo" autocomplete="off">
+        </label>
+        <label class="filter-field">
+          <span data-i18n="labelYear">Год издания</span>
+          <input type="text" inputmode="numeric" data-filter="year" data-i18n-placeholder="placeholderYear" placeholder="Например: 2018" autocomplete="off">
+        </label>
+        <label class="filter-field">
+          <span data-i18n="labelSpecialty">Специальность / раздел</span>
+          <input type="text" data-filter="specialty" data-i18n-placeholder="placeholderSpecialty" placeholder="Например: нейрохирургия" autocomplete="off">
+        </label>
+        <label class="filter-field">
+          <span data-i18n="labelLanguage">Язык</span>
+          <input type="text" data-filter="language" data-i18n-placeholder="placeholderLanguage" placeholder="Например: EN" autocomplete="off">
+        </label>
+      </div>
+      <div class="filter-actions">
+        <button class="button button--primary" type="button" id="reset-filters" data-i18n="reset">Сбросить фильтры</button>
       </div>
     </section>
-    <section id="card-results" class="card-results" aria-live="polite"></section>
+    <section class="status-bar">
+      <span class="status-pill" id="status-pill">—</span>
+    </section>
+    <section id="book-grid" class="book-grid" aria-live="polite"></section>
   </main>
   <footer>
-    <div class="footer-container">
-      <div class="contact-info">
-        <p>
-          <span data-lang="ru" class="lang">Контактный телефон:</span>
-          <span data-lang="en" class="lang">Phone:</span>
-          <span data-lang="tm" class="lang">Telefon:</span>
-          <a href="tel:+99362234094">+99362234094</a>
-        </p>
-        <p>
-          <span data-lang="ru" class="lang">Email:</span>
-          <span data-lang="en" class="lang">Email:</span>
-          <span data-lang="tm" class="lang">Email:</span>
-          <a href="mailto:tdlipf@gmail.com">tdlipf@gmail.com</a>
-        </p>
+    <div class="footer-content">
+      <div>
+        <strong data-i18n="contactTitle">Контакты</strong>
+        <p><span data-i18n="contactPhone">Телефон:</span> <a href="tel:+99362234094">+993 62 23 40 94</a></p>
+        <p><span data-i18n="contactEmail">Email:</span> <a href="mailto:tdlipf@gmail.com">tdlipf@gmail.com</a></p>
       </div>
-      <div class="footer-nav">
-        <a href="index.html" data-lang="ru" class="lang">Главная</a>
-        <a href="index.html" data-lang="en" class="lang">Home</a>
-        <a href="index.html" data-lang="tm" class="lang">Baş sahypa</a>
+      <div>
+        <strong data-i18n="footerNavigation">Навигация</strong>
+        <p><a href="index.html" data-i18n="navHome">Главная</a></p>
+        <p><a href="BookCategory.html" data-i18n="navCategories">Категории</a></p>
       </div>
-      <div class="copyright">
-        <p data-lang="ru" class="lang">&copy; 2025 Медицинская электронная библиотека. Все права защищены.</p>
-        <p data-lang="en" class="lang">&copy; 2025 Medical e-Library. All rights reserved.</p>
-        <p data-lang="tm" class="lang">&copy; 2025 Elektron lukmançylyk kitaphanasy. Ähli hukuklar goralan.</p>
+      <div>
+        <strong data-i18n="footerRights">© 2025 Медицинская электронная библиотека</strong>
+        <p data-i18n="footerText">Все права защищены. Проект создан для удобного доступа к медицинской литературе.</p>
       </div>
     </div>
   </footer>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.18.5/xlsx.full.min.js"></script>
-  <script defer src="scripts.js"></script>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/xlsx/0.19.3/xlsx.full.min.js" integrity="sha512-U+Sj1erWIVqABVqq9Kd7lLaZRmezMXCwiyC54m0tMpp7rKeOsXsu0JChnMSzlm4bzYI9JTYYZNNS45T8g11W0g==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+  <script>
+    const translations = {
+      ru: {
+        pageTitle: 'Медицинская электронная библиотека — книги',
+        tagline: 'Медицинская электронная библиотека',
+        heroTitle: 'Каталог медицинских книг',
+        languageLabel: 'Язык интерфейса:',
+        navHome: 'Главная',
+        navCategories: 'Категории',
+        navBooks: 'Каталог книг',
+        navAltSite: 'Другой сайт библиотеки',
+        filterEyebrow: 'Фильтр книг',
+        filterTitle: 'Найдите нужную литературу',
+        filterSubtitle: 'Используйте отдельные поля ниже, чтобы быстро отфильтровать книги по названию, автору, году, разделу и языку.',
+        labelTitle: 'Название книги',
+        labelAuthor: 'Автор',
+        labelYear: 'Год издания',
+        labelSpecialty: 'Специальность / раздел',
+        labelLanguage: 'Язык',
+        placeholderTitle: 'Например: нейрохирургия',
+        placeholderAuthor: 'Например: Apuzzo',
+        placeholderYear: 'Например: 2018',
+        placeholderSpecialty: 'Например: радиология',
+        placeholderLanguage: 'Например: EN',
+        reset: 'Сбросить фильтры',
+        statusLoading: 'Загружаем каталог...',
+        statusEmpty: 'Ничего не найдено',
+        statusTotal: 'Всего книг: {count}',
+        statusFiltered: 'Найдено {count} из {total}',
+        cardSpecialty: 'Раздел',
+        cardYear: 'Год',
+        cardLanguage: 'Язык',
+        cardAuthor: 'Автор',
+        cardCity: 'Город',
+        cardPublisher: 'Издательство',
+        cardPages: 'Страниц',
+        cardOpen: 'Открыть файл',
+        cardSearch: 'Найти книгу',
+        cardSpecialtyEmpty: 'Не указано',
+        cardLanguageEmpty: '—',
+        contactTitle: 'Контакты',
+        contactPhone: 'Телефон:',
+        contactEmail: 'Email:',
+        footerNavigation: 'Навигация',
+        footerRights: '© 2025 Медицинская электронная библиотека',
+        footerText: 'Все права защищены. Проект создан для удобного доступа к медицинской литературе.'
+      },
+      en: {
+        pageTitle: 'Medical e-Library — books',
+        tagline: 'Medical digital library',
+        heroTitle: 'Medical book catalogue',
+        languageLabel: 'Interface language:',
+        navHome: 'Home',
+        navCategories: 'Book categories',
+        navBooks: 'Book list',
+        navAltSite: 'Alternative library site',
+        filterEyebrow: 'Book filters',
+        filterTitle: 'Find the right resource',
+        filterSubtitle: 'Use the dedicated fields below to filter books by title, author, year, specialty and language in real time.',
+        labelTitle: 'Book title',
+        labelAuthor: 'Author',
+        labelYear: 'Year',
+        labelSpecialty: 'Specialty / section',
+        labelLanguage: 'Language',
+        placeholderTitle: 'e.g. neurosurgery',
+        placeholderAuthor: 'e.g. Apuzzo',
+        placeholderYear: 'e.g. 2018',
+        placeholderSpecialty: 'e.g. radiology',
+        placeholderLanguage: 'e.g. EN',
+        reset: 'Reset filters',
+        statusLoading: 'Loading catalogue...',
+        statusEmpty: 'No books match your filters',
+        statusTotal: 'Total books: {count}',
+        statusFiltered: 'Showing {count} of {total}',
+        cardSpecialty: 'Specialty',
+        cardYear: 'Year',
+        cardLanguage: 'Language',
+        cardAuthor: 'Author',
+        cardCity: 'City',
+        cardPublisher: 'Publisher',
+        cardPages: 'Pages',
+        cardOpen: 'Open file',
+        cardSearch: 'Search online',
+        cardSpecialtyEmpty: 'Not specified',
+        cardLanguageEmpty: '—',
+        contactTitle: 'Contacts',
+        contactPhone: 'Phone:',
+        contactEmail: 'Email:',
+        footerNavigation: 'Navigation',
+        footerRights: '© 2025 Medical e-Library',
+        footerText: 'All rights reserved. The project was created to provide convenient access to medical literature.'
+      },
+      tm: {
+        pageTitle: 'Lukmançylyk elektron kitaphanasy — kitaplar',
+        tagline: 'Lukmançylyk elektron kitaphanasy',
+        heroTitle: 'Lukmançylyk kitaplary kataloogy',
+        languageLabel: 'Interfeýsiň dili:',
+        navHome: 'Baş sahypa',
+        navCategories: 'Kategoriýalar',
+        navBooks: 'Kitap katalogy',
+        navAltSite: 'Kitaphananyň beýleki sahypasy',
+        filterEyebrow: 'Kitap süzgüçleri',
+        filterTitle: 'Gerek kitaby tapyň',
+        filterSubtitle: 'Aşakdaky meýdançalar arkaly kitabyny ady, awtory, ýyly, ugry we dili boýunça dessine saýlap bilersiňiz.',
+        labelTitle: 'Kitabyň ady',
+        labelAuthor: 'Awtor',
+        labelYear: 'Çykan ýyly',
+        labelSpecialty: 'Ugry / bölüm',
+        labelLanguage: 'Dil',
+        placeholderTitle: 'Mysal üçin: neýrohirurgiýa',
+        placeholderAuthor: 'Mysal üçin: Apuzzo',
+        placeholderYear: 'Mysal üçin: 2018',
+        placeholderSpecialty: 'Mysal üçin: radiologiýa',
+        placeholderLanguage: 'Mysal üçin: TM',
+        reset: 'Süzgüçleri arassala',
+        statusLoading: 'Katalog ýüklenýär...',
+        statusEmpty: 'Talaplara laýyk kitap tapylmady',
+        statusTotal: 'Jemi kitap: {count}',
+        statusFiltered: '{total} kitabyň {count}-si görkezildi',
+        cardSpecialty: 'Ugry',
+        cardYear: 'Ýyl',
+        cardLanguage: 'Dil',
+        cardAuthor: 'Awtor',
+        cardCity: 'Şäher',
+        cardPublisher: 'Neşirçi',
+        cardPages: 'Sahypa',
+        cardOpen: 'Faýly aç',
+        cardSearch: 'Internetden tap',
+        cardSpecialtyEmpty: 'Gösterilmedik',
+        cardLanguageEmpty: '—',
+        contactTitle: 'Habarlaşmak üçin',
+        contactPhone: 'Telefon:',
+        contactEmail: 'Email:',
+        footerNavigation: 'Navigasiýa',
+        footerRights: '© 2025 Lukmançylyk elektron kitaphanasy',
+        footerText: 'Ähli hukuklar goralan. Taslama lukmançylyk edebiýatyna amatly elýeterlik üçin döredildi.'
+      }
+    };
+
+    const columnAliases = {
+      title: ['Название книги', 'Book Name', 'Book Title', 'Kitaplar', 'Kitabyň ady', 'Name'],
+      author: ['Имя автора', 'Authors Name', 'Author', 'Awtoryň ady'],
+      publisher: ['Издатель', 'Publisher', 'Neşirçi'],
+      city: ['Город публикации', 'Publication City', 'City', 'Şäher'],
+      year: ['Год публикации', 'Publication Year', 'Год', 'Year', 'Ýyl'],
+      pages: ['Количество страниц', 'Page Count', 'Pages', 'Sahypalar'],
+      language: ['Язык книги', 'Book Language', 'Dil', 'Language'],
+      specialty: ['Специальность', 'Специальность / раздел', 'Раздел', 'Категория', 'Category', 'Specialty', 'Bölüm', 'Ugry'],
+      link: ['Ссылка', 'Link', 'URL', 'Download', 'Файл', 'File']
+    };
+
+    const state = {
+      lang: document.documentElement.lang || 'ru',
+      books: [],
+      filters: {
+        title: '',
+        author: '',
+        year: '',
+        specialty: '',
+        language: ''
+      }
+    };
+
+    document.addEventListener('DOMContentLoaded', () => {
+      initLanguageSwitcher();
+      initFilters();
+      loadBooks();
+    });
+
+    function initLanguageSwitcher() {
+      const select = document.getElementById('language-select');
+      if (!select) return;
+      select.value = state.lang;
+      select.addEventListener('change', () => {
+        state.lang = select.value;
+        document.documentElement.lang = state.lang;
+        document.documentElement.dataset.lang = state.lang;
+        applyTranslations();
+        renderBooks();
+      });
+      applyTranslations();
+    }
+
+    function applyTranslations() {
+      const dict = translations[state.lang] || translations.ru;
+      document.title = dict.pageTitle;
+      document.querySelectorAll('[data-i18n]').forEach((node) => {
+        const key = node.dataset.i18n;
+        if (dict[key]) {
+          node.textContent = dict[key];
+        }
+      });
+      document.querySelectorAll('[data-i18n-placeholder]').forEach((input) => {
+        const key = input.dataset.i18nPlaceholder;
+        if (dict[key]) {
+          input.placeholder = dict[key];
+        }
+      });
+    }
+
+    function initFilters() {
+      const form = document.getElementById('filter-form');
+      form?.querySelectorAll('input[data-filter]').forEach((input) => {
+        input.addEventListener('input', (event) => {
+          const target = event.currentTarget;
+          const name = target.dataset.filter;
+          state.filters[name] = target.value.trim().toLowerCase();
+          renderBooks();
+        });
+      });
+      document.getElementById('reset-filters')?.addEventListener('click', () => {
+        Object.keys(state.filters).forEach((key) => (state.filters[key] = ''));
+        form?.querySelectorAll('input[data-filter]').forEach((input) => {
+          input.value = '';
+        });
+        renderBooks();
+      });
+    }
+
+    function loadBooks() {
+      updateStatus('statusLoading');
+      if (typeof XLSX === 'undefined') {
+        updateStatus('statusEmpty');
+        console.error('XLSX library is not available');
+        return;
+      }
+      fetch('Book.xls')
+        .then((response) => {
+          if (!response.ok) {
+            throw new Error('Network error');
+          }
+          return response.arrayBuffer();
+        })
+        .then((buffer) => {
+          const workbook = XLSX.read(buffer, { type: 'array' });
+          const sheet = workbook.Sheets[workbook.SheetNames[0]];
+          const rows = XLSX.utils.sheet_to_json(sheet, { defval: '' });
+          state.books = rows
+            .map((row) => normalizeRow(row))
+            .filter((book) => book.title || book.author);
+          renderBooks();
+        })
+        .catch((error) => {
+          console.error(error);
+          updateStatus('statusEmpty');
+          const grid = document.getElementById('book-grid');
+          if (grid) {
+            grid.innerHTML = `<div class="empty-state">${translations[state.lang].statusEmpty}</div>`;
+          }
+        });
+    }
+
+    function normalizeRow(row) {
+      const getValue = (keys) => {
+        for (const key of keys) {
+          if (row[key] !== undefined && row[key] !== null) {
+            const value = String(row[key]).trim();
+            if (value) {
+              return value;
+            }
+          }
+        }
+        return '';
+      };
+      return {
+        title: getValue(columnAliases.title),
+        author: getValue(columnAliases.author),
+        publisher: getValue(columnAliases.publisher),
+        city: getValue(columnAliases.city),
+        year: getValue(columnAliases.year),
+        pages: getValue(columnAliases.pages),
+        language: getValue(columnAliases.language),
+        specialty: getValue(columnAliases.specialty),
+        link: getValue(columnAliases.link)
+      };
+    }
+
+    function renderBooks() {
+      const grid = document.getElementById('book-grid');
+      if (!grid) return;
+      const dict = translations[state.lang] || translations.ru;
+      const books = getFilteredBooks();
+      if (!state.books.length) {
+        grid.innerHTML = `<div class="empty-state">${dict.statusLoading}</div>`;
+        updateStatus('statusLoading');
+        return;
+      }
+      grid.innerHTML = '';
+      if (!books.length) {
+        grid.innerHTML = `<div class="empty-state">${dict.statusEmpty}</div>`;
+      } else {
+        const fragment = document.createDocumentFragment();
+        books.forEach((book) => {
+          fragment.appendChild(createBookCard(book, dict));
+        });
+        grid.appendChild(fragment);
+      }
+      updateCountStatus(books.length, state.books.length);
+    }
+
+    function getFilteredBooks() {
+      return state.books.filter((book) => {
+        if (state.filters.title && !(book.title || '').toLowerCase().includes(state.filters.title)) {
+          return false;
+        }
+        if (state.filters.author && !(book.author || '').toLowerCase().includes(state.filters.author)) {
+          return false;
+        }
+        if (state.filters.year && !(book.year || '').toLowerCase().includes(state.filters.year)) {
+          return false;
+        }
+        if (state.filters.specialty && !(book.specialty || '').toLowerCase().includes(state.filters.specialty)) {
+          return false;
+        }
+        if (state.filters.language && !(book.language || '').toLowerCase().includes(state.filters.language)) {
+          return false;
+        }
+        return true;
+      });
+    }
+
+    function createBookCard(book, dict) {
+      const article = document.createElement('article');
+      article.className = 'book-card';
+      const specialty = book.specialty || dict.cardSpecialtyEmpty;
+      const language = book.language || dict.cardLanguageEmpty;
+      const link = book.link || `https://www.google.com/search?q=${encodeURIComponent(book.title + ' ' + book.author)}`;
+      const isExternal = Boolean(book.link);
+      article.innerHTML = `
+        <div class="book-card__top">
+          <span class="book-card__chip">${specialty}</span>
+          <span class="book-card__chip">${book.year || dict.cardYear}</span>
+        </div>
+        <div>
+          <h3 class="book-card__title">${book.title || dict.cardSpecialtyEmpty}</h3>
+          <p class="book-card__author">${dict.cardAuthor}: ${book.author || '—'}</p>
+        </div>
+        <div class="book-card__details">
+          <div>
+            <span class="book-card__label">${dict.cardLanguage}</span>
+            <strong>${language}</strong>
+          </div>
+          <div>
+            <span class="book-card__label">${dict.cardPublisher}</span>
+            <strong>${book.publisher || '—'}</strong>
+          </div>
+          <div>
+            <span class="book-card__label">${dict.cardCity}</span>
+            <strong>${book.city || '—'}</strong>
+          </div>
+          <div>
+            <span class="book-card__label">${dict.cardPages}</span>
+            <strong>${book.pages || '—'}</strong>
+          </div>
+        </div>
+      `;
+      const actions = document.createElement('div');
+      actions.className = 'book-card__actions';
+      const button = document.createElement('a');
+      button.className = 'book-card__link';
+      button.textContent = isExternal ? dict.cardOpen : dict.cardSearch;
+      button.href = link;
+      button.target = '_blank';
+      button.rel = 'noopener';
+      actions.appendChild(button);
+      article.appendChild(actions);
+      return article;
+    }
+
+    function updateStatus(key) {
+      const pill = document.getElementById('status-pill');
+      if (!pill) return;
+      const dict = translations[state.lang] || translations.ru;
+      const template = dict[key];
+      pill.textContent = template || '';
+    }
+
+    function updateCountStatus(count, total) {
+      const pill = document.getElementById('status-pill');
+      if (!pill) return;
+      const dict = translations[state.lang] || translations.ru;
+      const key = count === total ? 'statusTotal' : 'statusFiltered';
+      const template = dict[key] || '';
+      pill.textContent = template.replace('{count}', count).replace('{total}', total);
+    }
+  </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the table-centric layout with a modern responsive card grid that highlights each book with hover effects and action buttons
- add a dedicated filter panel with individual search inputs, a reset control, and improved tri-lingual interface text handled entirely on the client
- update the JavaScript to load the Excel catalogue, normalize rows, render cards, and translate UI labels/status messages dynamically

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919aa5b39f48329ac803999bb5ec130)