### PR TITLE
Switch catalog to Book.xlsx and parse cover column

### DIFF
--- a/book.html
+++ b/book.html
@@ -615,13 +615,13 @@
       language: ['Язык книги', 'Book Language', 'Dil', 'Language'],
       specialty: ['Специальность', 'Специальность / раздел', 'Раздел', 'Категория', 'Category', 'Specialty', 'Bölüm', 'Ugry'],
       link: ['Ссылка', 'Link', 'URL', 'Download', 'Файл', 'File'],
-      cover: ['Обложка', 'Изображение', 'Фото', 'Cover', 'Image', 'Book image']
+      cover: ['Обложка', 'Изображение', 'Фото', 'Cover', 'Image', 'Book image', 'H', '__COL_H']
     };
 
     const BOOK_CACHE_KEY = 'medlibrary.bookCache';
     const BOOK_CACHE_VERSION = '2.0.0';
     const BOOK_CACHE_TTL = 1000 * 60 * 60 * 12; // 12 hours
-    const excelSources = ['Book.xlsx', 'Book.xls'];
+    const excelSources = ['Book.xlsx'];
     const fallbackCoverImages = ['1.webp', '2.webp', '3.webp', '4.webp', '5.webp', '6.webp', '1.png', '2.png', '3.png', '4.png', '5.png', '6.png'];
     const fallbackCoverCache = new Map();
 
@@ -739,7 +739,8 @@
           const buffer = await response.arrayBuffer();
           const workbook = XLSX.read(buffer, { type: 'array' });
           const sheet = workbook.Sheets[workbook.SheetNames[0]];
-          const rows = XLSX.utils.sheet_to_json(sheet, { defval: '' });
+          const rawRows = XLSX.utils.sheet_to_json(sheet, { header: 1, defval: '' });
+          const rows = convertSheetRowsToObjects(rawRows);
           const books = rows
             .map((row) => normalizeRow(row))
             .filter((book) => book.title || book.author);
@@ -870,6 +871,67 @@
         }
       }
       return rows;
+    }
+
+    function convertSheetRowsToObjects(rawRows) {
+      if (!Array.isArray(rawRows) || rawRows.length <= 1) {
+        return [];
+      }
+      const width = rawRows.reduce((max, row) => Math.max(max, Array.isArray(row) ? row.length : 0), 0);
+      if (width === 0) {
+        return [];
+      }
+      const headerRow = rawRows[0];
+      const normalizedHeaders = Array.from({ length: width }, (_, index) => {
+        const cell = headerRow[index];
+        if (typeof cell === 'string') {
+          const trimmed = cell.trim();
+          if (trimmed) {
+            return trimmed;
+          }
+        }
+        return '';
+      });
+      const result = [];
+      for (let rowIndex = 1; rowIndex < rawRows.length; rowIndex += 1) {
+        const row = Array.isArray(rawRows[rowIndex]) ? rawRows[rowIndex] : [];
+        const record = {};
+        let hasValue = false;
+        for (let colIndex = 0; colIndex < width; colIndex += 1) {
+          const value = row[colIndex] ?? '';
+          const hasCellValue =
+            typeof value === 'number'
+              ? true
+              : typeof value === 'string'
+              ? Boolean(value.trim())
+              : Boolean(value);
+          if (hasCellValue) {
+            hasValue = true;
+          }
+          const header = normalizedHeaders[colIndex];
+          if (header) {
+            record[header] = value;
+          }
+          record[`__COL_${getColumnLetter(colIndex)}`] = value;
+        }
+        if (hasValue) {
+          result.push(record);
+        }
+      }
+      return result;
+    }
+
+    function getColumnLetter(index) {
+      let letter = '';
+      let current = Number(index);
+      if (!Number.isFinite(current) || current < 0) {
+        return '';
+      }
+      while (current >= 0) {
+        letter = String.fromCharCode((current % 26) + 65) + letter;
+        current = Math.floor(current / 26) - 1;
+      }
+      return letter;
     }
 
     function normalizeRow(row) {

--- a/index.html
+++ b/index.html
@@ -209,17 +209,17 @@
           <ul data-lang="ru" class="lang">
             <li>Поиск моментально фильтрует таблицу книг.</li>
             <li>Скрипт бережно обрабатывает отсутствие данных или сети.</li>
-            <li>Поддерживается загрузка из Excel-файла Book.xls.</li>
+            <li>Поддерживается загрузка из Excel-файла Book.xlsx.</li>
           </ul>
           <ul data-lang="en" class="lang">
             <li>Live search instantly filters the book table.</li>
             <li>Scripts guard against empty data or offline states.</li>
-            <li>Data loads directly from the Book.xls spreadsheet.</li>
+            <li>Data loads directly from the Book.xlsx spreadsheet.</li>
           </ul>
           <ul data-lang="tm" class="lang">
             <li>Gözleg tablisadaky kitaplary bada-bat süzýär.</li>
             <li>Skriptler maglumat bolmadyk ýagdaýlary seresap saklaýar.</li>
-            <li>Maglumat Book.xls faýlyndan gönüden-göni alynýar.</li>
+            <li>Maglumat Book.xlsx faýlyndan gönüden-göni alynýar.</li>
           </ul>
           <a class="feature-cta lang" data-lang="ru" href="book.html">Открыть список книг</a>
           <a class="feature-cta lang" data-lang="en" href="book.html">Open the catalog</a>

--- a/scripts.js
+++ b/scripts.js
@@ -506,7 +506,7 @@ function initBookTable() {
     );
   };
 
-  fetch("Book.xls")
+  fetch("Book.xlsx")
     .then((response) => {
       if (!response.ok) {
         throw new Error("Network response was not ok " + response.statusText);


### PR DESCRIPTION
## Summary
- update the catalog loader and the book table to read from Book.xlsx instead of the deprecated Book.xls file
- normalize Excel rows with column-letter aliases so cover URLs can be read from column H of the sheet
- refresh the landing page copy so it references the new Book.xlsx data source

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919c26a92288329b65e820c68f319da)