### PR TITLE
Add modal authentication window

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,13 +18,31 @@
 </head>
 <body data-api-base="http://localhost:5000" data-google-client-id="">
   <header>
-    <select id="language-select">
-      <option value="tm">Türkmençe</option>
-      <option value="ru">Русский</option>
-      <option value="en">English</option>
-    </select>
-    <div id="auth" aria-labelledby="auth-heading">
-      <div class="auth-header">
+    <div class="header-controls">
+      <select id="language-select">
+        <option value="tm">Türkmençe</option>
+        <option value="ru">Русский</option>
+        <option value="en">English</option>
+      </select>
+      <button id="auth-open-button" class="auth-open-button" type="button">
+        <span data-lang="ru" class="lang">Регистрация / Вход</span>
+        <span data-lang="en" class="lang">Sign up / Sign in</span>
+        <span data-lang="tm" class="lang">Hasaba al / Içeri gir</span>
+      </button>
+    </div>
+
+    <h1 data-lang="ru" class="lang">Медицинская электронная библиотека</h1>
+    <h1 data-lang="en" class="lang">Medical e-Library</h1>
+    <h1 data-lang="tm" class="lang">Elektron lukmançylyk kitaphanasy</h1>
+  </header>
+
+  <div id="auth-modal" class="auth-modal" hidden aria-hidden="true">
+    <div class="auth-modal__dialog" role="dialog" aria-modal="true" aria-labelledby="auth-heading">
+      <button id="auth-close-button" class="auth-modal__close" type="button" aria-label="Закрыть окно авторизации">
+        ×
+      </button>
+      <div id="auth" aria-labelledby="auth-heading">
+        <div class="auth-header">
         <h2 id="auth-heading">Регистрация и вход</h2>
         <div class="auth-tabs" role="tablist">
           <button
@@ -124,11 +142,8 @@
         <button id="logout-button" type="button" hidden>Выйти</button>
       </div>
     </div>
-
-    <h1 data-lang="ru" class="lang">Медицинская электронная библиотека</h1>
-    <h1 data-lang="en" class="lang">Medical e-Library</h1>
-    <h1 data-lang="tm" class="lang">Elektron lukmançylyk kitaphanasy</h1>
-  </header>
+  </div>
+  </div>
   <nav>
     <a href="index.html" data-lang="ru" class="lang">Главная</a>
     <a href="index.html" data-lang="en" class="lang">Home</a>
@@ -232,9 +247,9 @@
             <li>Ulgam maglumatlary ugratmazdan öň barlaýar.</li>
             <li>Formanyň aşagynda ýükleme, üstünlik ýa-da säwlik habar berilýär.</li>
           </ul>
-          <a class="feature-cta lang" data-lang="ru" href="#auth">Перейти к регистрации</a>
-          <a class="feature-cta lang" data-lang="en" href="#auth">Start registration</a>
-          <a class="feature-cta lang" data-lang="tm" href="#auth">Hasaba başlaň</a>
+          <a class="feature-cta lang auth-trigger" data-lang="ru" href="#auth-modal" role="button">Перейти к регистрации</a>
+          <a class="feature-cta lang auth-trigger" data-lang="en" href="#auth-modal" role="button">Start registration</a>
+          <a class="feature-cta lang auth-trigger" data-lang="tm" href="#auth-modal" role="button">Hasaba başlaň</a>
         </article>
         <article class="feature-card" role="listitem">
           <div class="feature-icon" aria-hidden="true">📚</div>

--- a/styles.css
+++ b/styles.css
@@ -52,6 +52,76 @@ body.book-page {
     color: #111;
 }
 
+.header-controls {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.75rem;
+}
+
+.auth-open-button {
+    border-radius: 999px;
+    border: 1px solid #ffffffb3;
+    background: transparent;
+    color: #fff;
+    padding: 0.45rem 1.5rem;
+    font-weight: 600;
+    cursor: pointer;
+    display: inline-flex;
+    gap: 0.35rem;
+    align-items: center;
+    justify-content: center;
+    transition: background-color var(--transition), color var(--transition);
+}
+
+.auth-open-button:hover,
+.auth-open-button:focus-visible {
+    background-color: #fff;
+    color: #0d324d;
+}
+
+.auth-modal {
+    position: fixed;
+    inset: 0;
+    background: rgba(0, 0, 0, 0.6);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 1rem;
+    z-index: 1000;
+}
+
+.auth-modal[hidden] {
+    display: none;
+}
+
+.auth-modal__dialog {
+    position: relative;
+    max-width: 420px;
+    width: 100%;
+}
+
+.auth-modal__close {
+    position: absolute;
+    top: -12px;
+    right: -12px;
+    border-radius: 50%;
+    border: none;
+    width: 32px;
+    height: 32px;
+    cursor: pointer;
+    background: #ffffff;
+    color: #0d324d;
+    font-size: 1.4rem;
+    line-height: 1;
+    box-shadow: 0 4px 14px rgba(0, 0, 0, 0.2);
+}
+
+body.modal-open {
+    overflow: hidden;
+}
+
 @media (min-width: 768px) {
     .book-page header {
         justify-content: space-between;
@@ -61,8 +131,8 @@ body.book-page {
 
 #auth {
     max-width: 360px;
-    margin: 1rem auto;
-    background: #ffffff10;
+    margin: 0 auto;
+    background: #ffffff;
     padding: 1.5rem;
     border-radius: 12px;
     box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);


### PR DESCRIPTION
## Summary
- wrap the existing authentication forms in a dedicated modal window that is opened from the header button or feature CTA links
- add the required overlay/button styling and prevent background scrolling when the dialog is visible
- introduce a modal controller in scripts.js and close the dialog automatically after successful registration or login (including Google login)

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6919f6cf9c408329b288febb4984b483)