### PR TITLE
Generate offline installer on demand

### DIFF
--- a/index.html
+++ b/index.html
@@ -155,6 +155,10 @@
     <a href="#about" data-lang="en" class="lang">About</a>
     <a href="#about" data-lang="tm" class="lang">Kitaphana barada</a>
 
+    <a href="#download" data-lang="ru" class="lang">Скачать приложение</a>
+    <a href="#download" data-lang="en" class="lang">Download app</a>
+    <a href="#download" data-lang="tm" class="lang">Programmany indir</a>
+
     <a href="#features" data-lang="ru" class="lang">Особенности</a>
     <a href="#features" data-lang="en" class="lang">Features</a>
     <a href="#features" data-lang="tm" class="lang">Aýratynlyklary</a>
@@ -189,6 +193,113 @@
     </a>
   </nav>
   <main class="container">
+    <section
+      id="download"
+      class="hero"
+      aria-labelledby="download-heading"
+    >
+      <div class="hero__content">
+        <p class="hero__eyebrow">
+          <span data-lang="ru" class="lang">PWA-приложение и офлайн-каталог</span>
+          <span data-lang="en" class="lang">PWA app and offline catalog</span>
+          <span data-lang="tm" class="lang">PWA programma we oflaýn katalog</span>
+        </p>
+        <h2 id="download-heading" class="hero__title">
+          <span data-lang="ru" class="lang">Доступ к библиотеке в один тап</span>
+          <span data-lang="en" class="lang">Library access in one tap</span>
+          <span data-lang="tm" class="lang">Kitaphana elýeterligi bir basmada</span>
+        </h2>
+        <p class="hero__text">
+          <span data-lang="ru" class="lang">
+            Установите MedLibrary как приложение или скачайте установочный файл, чтобы
+            пользоваться всеми 1000+ книг офлайн.
+          </span>
+          <span data-lang="en" class="lang">
+            Install MedLibrary as a PWA or download the installer archive to keep 1000+
+            medical books with you offline.
+          </span>
+          <span data-lang="tm" class="lang">
+            MedLibrary programmasyny goýberiň ýa-da gurmak faýlyny ýükläp alň,
+            1000+ lukmançylyk kitabyny oflaýn saklaň.
+          </span>
+        </p>
+        <ul class="hero__features">
+          <li>
+            <span data-lang="ru" class="lang">Работает без интернета</span>
+            <span data-lang="en" class="lang">Works without internet</span>
+            <span data-lang="tm" class="lang">Internet bolmazdan işleýär</span>
+          </li>
+          <li>
+            <span data-lang="ru" class="lang">Поддержка Android, Windows, iOS</span>
+            <span data-lang="en" class="lang">Android, Windows, iOS support</span>
+            <span data-lang="tm" class="lang">Android, Windows, iOS goldawy</span>
+          </li>
+          <li>
+            <span data-lang="ru" class="lang">Обновления через GitHub Pages</span>
+            <span data-lang="en" class="lang">Updates via GitHub Pages</span>
+            <span data-lang="tm" class="lang">Täzelenmeler GitHub Pages arkaly</span>
+          </li>
+        </ul>
+        <div class="hero__actions">
+          <button id="install-button" class="cta-button" type="button" hidden>
+            <span data-lang="ru" class="lang">Скачать приложение</span>
+            <span data-lang="en" class="lang">Install app</span>
+            <span data-lang="tm" class="lang">Programmany goý</span>
+          </button>
+          <button
+            id="offline-download-button"
+            class="cta-button cta-button--ghost"
+            type="button"
+          >
+            <span data-lang="ru" class="lang">Создать установочный файл (.zip)</span>
+            <span data-lang="en" class="lang">Create installer (.zip)</span>
+            <span data-lang="tm" class="lang">Gurmak faýlyny döret (.zip)</span>
+          </button>
+        </div>
+        <div class="hero__status-list">
+          <p
+            id="install-hint"
+            class="install-hint"
+            data-i18n-key="installHintDefault"
+          >
+            Установка доступна в поддерживаемых браузерах.
+          </p>
+          <p
+            id="offline-download-status"
+            class="install-hint"
+            data-i18n-key="offlineIdle"
+          >
+            Сформируйте офлайн-архив одним нажатием.
+          </p>
+        </div>
+      </div>
+      <div class="hero__metrics" aria-label="Статистика библиотеки">
+        <article class="metric-card">
+          <p class="metric-card__value">1000+</p>
+          <p class="metric-card__label">
+            <span data-lang="ru" class="lang">медицинских книг</span>
+            <span data-lang="en" class="lang">medical books</span>
+            <span data-lang="tm" class="lang">lukmançylyk kitaplary</span>
+          </p>
+        </article>
+        <article class="metric-card">
+          <p class="metric-card__value">69</p>
+          <p class="metric-card__label">
+            <span data-lang="ru" class="lang">направлений</span>
+            <span data-lang="en" class="lang">specialties</span>
+            <span data-lang="tm" class="lang">ugur</span>
+          </p>
+        </article>
+        <article class="metric-card">
+          <p class="metric-card__value">3</p>
+          <p class="metric-card__label">
+            <span data-lang="ru" class="lang">языка интерфейса</span>
+            <span data-lang="en" class="lang">interface languages</span>
+            <span data-lang="tm" class="lang">interfeýs dili</span>
+          </p>
+        </article>
+      </div>
+    </section>
     <section id="about" aria-labelledby="about-heading">
       <h2 id="about-heading" data-lang="ru" class="lang">О библиотеке</h2>
       <h2 id="about-heading" data-lang="en" class="lang">About</h2>
@@ -429,7 +540,9 @@
     </div>
   </div>
     <script src="https://accounts.google.com/gsi/client" async defer></script>
+    <script defer src="offline-assets.js"></script>
     <script defer src="scripts.js"></script>
+    <script defer src="offline-download.js"></script>
     <script defer src="pwa.js"></script>
 </body>
 </html>

--- a/offline-assets.js
+++ b/offline-assets.js
@@ -1,0 +1,27 @@
+(function initOfflineAssetManifest(globalScope) {
+  const assets = [
+    "/MedLibrary/",
+    "/MedLibrary/index.html",
+    "/MedLibrary/book.html",
+    "/MedLibrary/books.html",
+    "/MedLibrary/books2.html",
+    "/MedLibrary/BookCategory.html",
+    "/MedLibrary/auth.html",
+    "/MedLibrary/auth.js",
+    "/MedLibrary/Book.xlsx",
+    "/MedLibrary/styles.css",
+    "/MedLibrary/scripts.js",
+    "/MedLibrary/lang.js",
+    "/MedLibrary/pwa.js",
+    "/MedLibrary/offline-assets.js",
+    "/MedLibrary/offline-download.js",
+    "/MedLibrary/manifest.webmanifest",
+    "/MedLibrary/service-worker.js",
+    "/MedLibrary/icons/icon-192.svg",
+    "/MedLibrary/icons/icon-512.svg",
+  ];
+
+  if (globalScope) {
+    globalScope.MEDLIBRARY_OFFLINE_ASSETS = assets;
+  }
+})(typeof self !== "undefined" ? self : window);

--- a/offline-download.js
+++ b/offline-download.js
@@ -1,0 +1,245 @@
+(function initOfflineInstaller() {
+  const downloadButton = document.getElementById("offline-download-button");
+  const statusElement = document.getElementById("offline-download-status");
+
+  if (!downloadButton || !statusElement) {
+    return;
+  }
+
+  const ZIP_FLAG_UTF8 = 0x0800;
+  const ZIP_VERSION = 20;
+
+  const setStatus = (key, replacements = {}, state) => {
+    statusElement.classList.remove("success", "error", "pending");
+    if (state) {
+      statusElement.classList.add(state);
+    }
+
+    if (typeof window.setElementTranslation === "function") {
+      window.setElementTranslation(statusElement, key, replacements);
+      return;
+    }
+
+    if (typeof window.translate === "function") {
+      statusElement.textContent = window.translate(key, replacements);
+      return;
+    }
+
+    statusElement.textContent = replacements?.message || "";
+  };
+
+  const getManifestAssets = () => {
+    if (!Array.isArray(window.MEDLIBRARY_OFFLINE_ASSETS)) {
+      return [];
+    }
+
+    const normalized = window.MEDLIBRARY_OFFLINE_ASSETS.filter(
+      (asset) => typeof asset === "string" && !asset.includes("downloads/medlibrary-offline.zip")
+    );
+
+    return Array.from(new Set(normalized));
+  };
+
+  const normalizeAssetPath = (asset) => {
+    if (!asset) {
+      return null;
+    }
+
+    const withoutOrigin = asset.replace(window.location.origin, "");
+    const trimmed = withoutOrigin.replace(/^\/+/, "");
+
+    if (!trimmed || trimmed === "MedLibrary" || trimmed === "MedLibrary/") {
+      return "MedLibrary/index.html";
+    }
+
+    if (trimmed.startsWith("MedLibrary/")) {
+      return trimmed;
+    }
+
+    return `MedLibrary/${trimmed}`;
+  };
+
+  const buildZipBlob = (files) => {
+    const encoder = new TextEncoder();
+    const fileRecords = [];
+    const chunks = [];
+    let offset = 0;
+
+    files.forEach(({ name, data }) => {
+      const nameBytes = encoder.encode(name);
+      const fileBytes = new Uint8Array(data);
+      const crc = calculateCrc32(fileBytes);
+      const { date, time } = getDosDateTime();
+
+      const localHeader = new Uint8Array(30 + nameBytes.length);
+      const localView = new DataView(localHeader.buffer);
+      localView.setUint32(0, 0x04034b50, true);
+      localView.setUint16(4, ZIP_VERSION, true);
+      localView.setUint16(6, ZIP_FLAG_UTF8, true);
+      localView.setUint16(8, 0, true);
+      localView.setUint16(10, time, true);
+      localView.setUint16(12, date, true);
+      localView.setUint32(14, crc >>> 0, true);
+      localView.setUint32(18, fileBytes.length, true);
+      localView.setUint32(22, fileBytes.length, true);
+      localView.setUint16(26, nameBytes.length, true);
+      localView.setUint16(28, 0, true);
+      localHeader.set(nameBytes, 30);
+
+      chunks.push(localHeader, fileBytes);
+      fileRecords.push({
+        nameBytes,
+        crc,
+        size: fileBytes.length,
+        offset,
+        date,
+        time,
+      });
+      offset += localHeader.length + fileBytes.length;
+    });
+
+    const centralChunks = [];
+    fileRecords.forEach((record) => {
+      const centralHeader = new Uint8Array(46 + record.nameBytes.length);
+      const centralView = new DataView(centralHeader.buffer);
+      centralView.setUint32(0, 0x02014b50, true);
+      centralView.setUint16(4, (3 << 8) | ZIP_VERSION, true);
+      centralView.setUint16(6, ZIP_FLAG_UTF8, true);
+      centralView.setUint16(8, 0, true);
+      centralView.setUint16(10, record.time, true);
+      centralView.setUint16(12, record.date, true);
+      centralView.setUint32(14, record.crc >>> 0, true);
+      centralView.setUint32(18, record.size, true);
+      centralView.setUint32(22, record.size, true);
+      centralView.setUint16(26, record.nameBytes.length, true);
+      centralView.setUint16(28, 0, true);
+      centralView.setUint16(30, 0, true);
+      centralView.setUint16(32, 0, true);
+      centralView.setUint16(34, 0, true);
+      centralView.setUint32(38, 0, true);
+      centralView.setUint32(42, record.offset, true);
+      centralHeader.set(record.nameBytes, 46);
+      centralChunks.push(centralHeader);
+    });
+
+    const centralSize = centralChunks.reduce((acc, chunk) => acc + chunk.length, 0);
+    const centralOffset = offset;
+
+    const endOfCentralDir = new Uint8Array(22);
+    const endView = new DataView(endOfCentralDir.buffer);
+    endView.setUint32(0, 0x06054b50, true);
+    endView.setUint16(4, 0, true);
+    endView.setUint16(6, 0, true);
+    endView.setUint16(8, fileRecords.length, true);
+    endView.setUint16(10, fileRecords.length, true);
+    endView.setUint32(12, centralSize, true);
+    endView.setUint32(16, centralOffset, true);
+    endView.setUint16(20, 0, true);
+
+    return new Blob([...chunks, ...centralChunks, endOfCentralDir], {
+      type: "application/zip",
+    });
+  };
+
+  const CRC32_TABLE = (() => {
+    const table = new Uint32Array(256);
+    for (let i = 0; i < 256; i += 1) {
+      let code = i;
+      for (let j = 0; j < 8; j += 1) {
+        code = code & 1 ? 0xedb88320 ^ (code >>> 1) : code >>> 1;
+      }
+      table[i] = code >>> 0;
+    }
+    return table;
+  })();
+
+  const calculateCrc32 = (bytes) => {
+    let crc = -1;
+    for (let i = 0; i < bytes.length; i += 1) {
+      const byte = bytes[i];
+      crc = CRC32_TABLE[(crc ^ byte) & 0xff] ^ (crc >>> 8);
+    }
+    return (crc ^ -1) >>> 0;
+  };
+
+  const getDosDateTime = () => {
+    const now = new Date();
+    const year = Math.max(now.getFullYear(), 1980);
+    const dosYear = year - 1980;
+    const dosMonth = now.getMonth() + 1;
+    const dosDay = now.getDate();
+    const dosHours = now.getHours();
+    const dosMinutes = now.getMinutes();
+    const dosSeconds = Math.floor(now.getSeconds() / 2);
+
+    return {
+      date: (dosYear << 9) | (dosMonth << 5) | dosDay,
+      time: (dosHours << 11) | (dosMinutes << 5) | dosSeconds,
+    };
+  };
+
+  const downloadArchive = async () => {
+    const manifestAssets = getManifestAssets();
+
+    if (!manifestAssets.length) {
+      setStatus("offlineMissingAssets", {}, "error");
+      return;
+    }
+
+    downloadButton.disabled = true;
+    setStatus("offlinePreparing", {}, "pending");
+
+    const files = [];
+    const seenFiles = new Set();
+
+    try {
+      for (let index = 0; index < manifestAssets.length; index += 1) {
+        const asset = manifestAssets[index];
+        const normalizedPath = normalizeAssetPath(asset);
+        if (!normalizedPath || seenFiles.has(normalizedPath)) {
+          continue;
+        }
+
+        setStatus(
+          "offlineProgress",
+          { current: index + 1, total: manifestAssets.length },
+          "pending"
+        );
+
+        const response = await fetch(asset, { cache: "no-cache" });
+        if (!response.ok) {
+          throw new Error(`Не удалось загрузить ${asset}`);
+        }
+
+        const buffer = await response.arrayBuffer();
+        files.push({ name: normalizedPath, data: buffer });
+        seenFiles.add(normalizedPath);
+      }
+
+      if (!files.length) {
+        setStatus("offlineMissingAssets", {}, "error");
+        downloadButton.disabled = false;
+        return;
+      }
+
+      const archiveBlob = buildZipBlob(files);
+      const blobUrl = URL.createObjectURL(archiveBlob);
+      const anchor = document.createElement("a");
+      anchor.href = blobUrl;
+      anchor.download = "medlibrary-offline.zip";
+      document.body.appendChild(anchor);
+      anchor.click();
+      anchor.remove();
+      window.setTimeout(() => URL.revokeObjectURL(blobUrl), 10000);
+
+      setStatus("offlineReady", {}, "success");
+    } catch (error) {
+      console.error("Failed to build offline archive", error);
+      setStatus("offlineError", {}, "error");
+    } finally {
+      downloadButton.disabled = false;
+    }
+  };
+
+  downloadButton.addEventListener("click", downloadArchive);
+})();

--- a/pwa.js
+++ b/pwa.js
@@ -11,3 +11,94 @@
       });
   });
 })();
+
+(function setupInstallPrompt() {
+  const installButton = document.getElementById("install-button");
+  const hintElement = document.getElementById("install-hint");
+  if (!installButton && !hintElement) {
+    return;
+  }
+
+  let deferredPrompt = null;
+  const fallbackTexts = {
+    installHintDefault: "Установка доступна в поддерживаемых браузерах.",
+    installHintReady: "Нажмите, чтобы установить приложение.",
+    installHintInstalled: "Приложение установлено на устройство.",
+  };
+
+  const translateText = (key) => {
+    if (typeof window.translate === "function") {
+      return window.translate(key);
+    }
+    return fallbackTexts[key] || fallbackTexts.installHintDefault;
+  };
+
+  const updateHint = (key) => {
+    if (!hintElement) {
+      return;
+    }
+    hintElement.dataset.i18nKey = key;
+    if (typeof window.translateElement === "function") {
+      window.translateElement(hintElement);
+      return;
+    }
+    hintElement.textContent = translateText(key);
+  };
+
+  const hideButton = () => {
+    if (installButton) {
+      installButton.hidden = true;
+      installButton.disabled = false;
+    }
+  };
+
+  const showButton = () => {
+    if (installButton) {
+      installButton.hidden = false;
+      installButton.disabled = false;
+    }
+  };
+
+  window.addEventListener("beforeinstallprompt", (event) => {
+    event.preventDefault();
+    deferredPrompt = event;
+    showButton();
+    updateHint("installHintReady");
+  });
+
+  installButton?.addEventListener("click", async () => {
+    if (!deferredPrompt) {
+      updateHint("installHintDefault");
+      return;
+    }
+
+    installButton.disabled = true;
+    const promptEvent = deferredPrompt;
+    promptEvent.prompt();
+    const { outcome } = await promptEvent.userChoice;
+    deferredPrompt = null;
+    installButton.disabled = false;
+
+    if (outcome === "accepted") {
+      updateHint("installHintInstalled");
+      hideButton();
+    } else {
+      updateHint("installHintReady");
+    }
+  });
+
+  window.addEventListener("appinstalled", () => {
+    deferredPrompt = null;
+    updateHint("installHintInstalled");
+    hideButton();
+  });
+
+  const isStandalone = () =>
+    window.matchMedia("(display-mode: standalone)").matches ||
+    window.navigator.standalone;
+
+  if (isStandalone()) {
+    updateHint("installHintInstalled");
+    hideButton();
+  }
+})();

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,22 +1,10 @@
+importScripts("/MedLibrary/offline-assets.js");
+
 const CACHE_NAME = "medlibrary-v1";
 
-const URLS_TO_CACHE = [
-  "/MedLibrary/",
-  "/MedLibrary/index.html",
-  "/MedLibrary/book.html",
-  "/MedLibrary/books.html",
-  "/MedLibrary/books2.html",
-  "/MedLibrary/BookCategory.html",
-  "/MedLibrary/auth.html",
-  "/MedLibrary/auth.js",
-  "/MedLibrary/styles.css",
-  "/MedLibrary/scripts.js",
-  "/MedLibrary/lang.js",
-  "/MedLibrary/pwa.js",
-  "/MedLibrary/manifest.webmanifest",
-  "/MedLibrary/icons/icon-192.svg",
-  "/MedLibrary/icons/icon-512.svg"
-];
+const URLS_TO_CACHE = Array.isArray(self.MEDLIBRARY_OFFLINE_ASSETS)
+  ? Array.from(new Set(self.MEDLIBRARY_OFFLINE_ASSETS))
+  : [];
 
 self.addEventListener("install", (event) => {
   event.waitUntil(

--- a/styles.css
+++ b/styles.css
@@ -360,6 +360,173 @@ nav a:hover {
     box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
 }
 
+.hero {
+    position: relative;
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: clamp(1.5rem, 4vw, 3rem);
+    padding: clamp(1.5rem, 4vw, 3rem);
+    border-radius: 32px;
+    margin-bottom: clamp(1.5rem, 4vw, 3rem);
+    color: #fff;
+    background: radial-gradient(circle at 20% 20%, rgba(255, 255, 255, 0.15), transparent 55%),
+        linear-gradient(135deg, #0d324d, #1d4f91);
+    overflow: hidden;
+}
+
+.hero::after {
+    content: "";
+    position: absolute;
+    inset: 0;
+    background: radial-gradient(circle at 80% 20%, rgba(255, 255, 255, 0.1), transparent 40%);
+    pointer-events: none;
+}
+
+.hero__content,
+.hero__metrics {
+    position: relative;
+    z-index: 1;
+}
+
+.hero__content {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+}
+
+.hero__eyebrow {
+    font-size: 0.9rem;
+    letter-spacing: 0.15em;
+    text-transform: uppercase;
+    color: rgba(255, 255, 255, 0.8);
+    margin: 0;
+}
+
+.hero__title {
+    margin: 0;
+    font-size: clamp(2rem, 4vw, 2.75rem);
+}
+
+.hero__text {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.9);
+}
+
+.hero__features {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    gap: 0.5rem;
+}
+
+.hero__features li {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.5rem 0.75rem;
+    border-radius: 999px;
+    background: rgba(255, 255, 255, 0.12);
+    font-weight: 600;
+}
+
+.hero__actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+    margin-top: 0.5rem;
+}
+
+.cta-button {
+    border: none;
+    border-radius: 999px;
+    padding: 0.85rem 1.75rem;
+    font-size: 1rem;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform var(--transition), box-shadow var(--transition), background-color var(--transition);
+    background: #ffb703;
+    color: #0d324d;
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.25rem;
+}
+
+.cta-button:hover,
+.cta-button:focus-visible {
+    transform: translateY(-1px);
+    box-shadow: 0 10px 25px rgba(0, 0, 0, 0.15);
+}
+
+.cta-button[hidden] {
+    display: none;
+}
+
+.cta-button--ghost {
+    background: transparent;
+    color: #fff;
+    border: 1px solid rgba(255, 255, 255, 0.5);
+}
+
+.cta-button:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.install-hint {
+    margin: 0;
+    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.85);
+}
+
+.install-hint.pending {
+    color: #ffecb3;
+}
+
+.install-hint.success {
+    color: #c8e6c9;
+}
+
+.install-hint.error {
+    color: #ffcdd2;
+}
+
+.hero__status-list {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    margin-top: 1rem;
+}
+
+.hero__metrics {
+    display: grid;
+    gap: 0.75rem;
+    grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+}
+
+.metric-card {
+    background: rgba(255, 255, 255, 0.12);
+    border-radius: 24px;
+    padding: 1rem;
+    text-align: center;
+    border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.metric-card__value {
+    margin: 0;
+    font-size: 2rem;
+    font-weight: 700;
+}
+
+.metric-card__label {
+    margin: 0;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.95rem;
+}
+
 .page-container {
     padding: clamp(1rem, 4vw, 2.5rem);
     max-width: 1200px;


### PR DESCRIPTION
## Summary
- replace the static ZIP link on the hero with a build-on-demand installer button and status text so users still get an offline archive without committing binaries
- add a shared offline asset manifest that feeds both the service worker cache list and the new generator script
- translate and style the new status messages while removing the committed ZIP from the repo

## Testing
- Not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691de3fd42f0832996180e8da662ab05)