### PR TITLE
Add specialties API and dynamic category table

### DIFF
--- a/BookCategory.html
+++ b/BookCategory.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="manifest" href="manifest.webmanifest">
 </head>
-<body>
+<body data-api-base="http://localhost:5000">
   <header class="site-header">
     <div class="site-header__brand">
       <p class="eyebrow lang" data-lang="ru">Категории библиотеки</p>
@@ -63,7 +63,7 @@
           <span class="lang" data-lang="tm">Kategoriýalar boýunça gözleg</span>
         </label>
         <input id="category-search" type="search" placeholder="Анатомия, Kardiologiýa..." autocomplete="off">
-        <p id="category-count" class="category-count">69 категорий</p>
+        <p id="category-count" class="category-count">—</p>
       </div>
       <div class="table-wrapper">
         <table class="category-table" aria-live="polite">
@@ -71,71 +71,13 @@
             <tr>
               <th>RU</th>
               <th>TM</th>
+              <th>Книг</th>
             </tr>
           </thead>
-          <tbody>
-            <tr data-category-row><td>Акушерство и Гинекология</td><td>Akuşerçilik we Ginekologiýa</td></tr>
-            <tr data-category-row><td>Анатомия</td><td>Anatomiýa</td></tr>
-            <tr data-category-row><td>Ангиография</td><td>Angiografiýa</td></tr>
-            <tr data-category-row><td>Английский язык</td><td>Iňlis dili</td></tr>
-            <tr data-category-row><td>Анестезиология</td><td>Anesteziologiýa</td></tr>
-            <tr data-category-row><td>Биохимия</td><td>Biohimiýa</td></tr>
-            <tr data-category-row><td>Внутренние болезни</td><td>Iç keseller</td></tr>
-            <tr data-category-row><td>Военно-полевая терапия</td><td>Harby-meýdan terapiýasy</td></tr>
-            <tr data-category-row><td>Военно-полевая хирургия</td><td>Harby-meýdan hirurgiýasy</td></tr>
-            <tr data-category-row><td>Гастроэнтерология</td><td>Gastroenterologiýa</td></tr>
-            <tr data-category-row><td>Гематология</td><td>Gematologiýa</td></tr>
-            <tr data-category-row><td>Гигиена</td><td>Gigiýena</td></tr>
-            <tr data-category-row><td>Гистология, цитология</td><td>Gistologiýa, sitologiýa</td></tr>
-            <tr data-category-row><td>Детская хирургия</td><td>Çaga hirurgiýasy</td></tr>
-            <tr data-category-row><td>Диетология</td><td>Dietologiýa</td></tr>
-            <tr data-category-row><td>Инфекционные болезни</td><td>Ýokanç keseller</td></tr>
-            <tr data-category-row><td>Инфекционные болезни детей</td><td>Çaga ýokanç keselleri</td></tr>
-            <tr data-category-row><td>История медицины</td><td>Lukmançylyk taryhy</td></tr>
-            <tr data-category-row><td>Кардиология</td><td>Kardiologiýa</td></tr>
-            <tr data-category-row><td>Кардиохирургия</td><td>Kardiohirurgiýa</td></tr>
-            <tr data-category-row><td>Клиническая лаборатория</td><td>Kliniki laboratoriýa</td></tr>
-            <tr data-category-row><td>Кожные и венерические болезни</td><td>Deri we weneriki keseller</td></tr>
-            <tr data-category-row><td>Компьютерная томография</td><td>Kompýuter tomografiýasy</td></tr>
-            <tr data-category-row><td>Латинский язык и медицинская терминология</td><td>Latin dili we lukmançylyk terminologiýasy</td></tr>
-            <tr data-category-row><td>Лечебная физкультура</td><td>Bejeriş beden terbiyesi</td></tr>
-            <tr data-category-row><td>Магнитно-резонансная томография</td><td>Magnit rezonans tomografiýasy</td></tr>
-            <tr data-category-row><td>Медицинская биология</td><td>Lukmançylyk biologiýasy</td></tr>
-            <tr data-category-row><td>Медицинская генетика</td><td>Lukmançylyk genetikasy</td></tr>
-            <tr data-category-row><td>Медицинская и биологическая физика</td><td>Lukmançylyk we biologik fizika</td></tr>
-            <tr data-category-row><td>Медицинская иммунология</td><td>Lukmançylyk immunologiýasy</td></tr>
-            <tr data-category-row><td>Микробиология</td><td>Mikrobiologiýa</td></tr>
-            <tr data-category-row><td>Наркология</td><td>Narkologiýa</td></tr>
-            <tr data-category-row><td>Неврология</td><td>Newrologiýa</td></tr>
-            <tr data-category-row><td>Нейрохирургия</td><td>Neýrohirurgiýa</td></tr>
-            <tr data-category-row><td>Неонатология</td><td>Neonatologiýa</td></tr>
-            <tr data-category-row><td>Общая и медицинская химия</td><td>Umumy we lukmançylyk himiýasy</td></tr>
-            <tr data-category-row><td>Общая и неорганическая химия</td><td>Umumy we organiki däl himiýa</td></tr>
-            <tr data-category-row><td>Онкология</td><td>Onkologiýa</td></tr>
-            <tr data-category-row><td>Ортопедия и травматология</td><td>Ortopediýa we trawmatologiýa</td></tr>
-            <tr data-category-row><td>Отоларингология</td><td>Otolaringologiýa</td></tr>
-            <tr data-category-row><td>Офтальмология</td><td>Oftalmologiýa</td></tr>
-            <tr data-category-row><td>Патологическая анатомия</td><td>Patologik anatomiýa</td></tr>
-            <tr data-category-row><td>Педиатрия</td><td>Pediatriýa</td></tr>
-            <tr data-category-row><td>Пластическая хирургия</td><td>Plastiki hirurgiýa</td></tr>
-            <tr data-category-row><td>Психиатрия</td><td>Psihiatriýa</td></tr>
-            <tr data-category-row><td>Психология</td><td>Psihologiýa</td></tr>
-            <tr data-category-row><td>Пульмонология</td><td>Pulmonologiýa</td></tr>
-            <tr data-category-row><td>Радиология</td><td>Radiologiýa</td></tr>
-            <tr data-category-row><td>Сердечно-сосудистая хирургия</td><td>Ýürek-damar hirurgiýasy</td></tr>
-            <tr data-category-row><td>Сестринское дело</td><td>Şepagat uýasy işi</td></tr>
-            <tr data-category-row><td>Судебная медицина</td><td>Kazyýet lukmançylygy</td></tr>
-            <tr data-category-row><td>Стоматология</td><td>Stomatologiýa</td></tr>
-            <tr data-category-row><td>Терапия</td><td>Terapia</td></tr>
-            <tr data-category-row><td>Травматология</td><td>Trawmatologiýa</td></tr>
-            <tr data-category-row><td>Ультразвуковая диагностика</td><td>Ultrases barlagy</td></tr>
-            <tr data-category-row><td>Фармакология</td><td>Farmakologiýa</td></tr>
-            <tr data-category-row><td>Физиология</td><td>Fiziologiýa</td></tr>
-            <tr data-category-row><td>Фтизиатрия</td><td>Ftiziatriýa</td></tr>
-            <tr data-category-row><td>Хирургия</td><td>Hirurgiýa</td></tr>
-            <tr data-category-row><td>Электрокардиография</td><td>Elektrokardiografiýa</td></tr>
-            <tr data-category-row><td>Эндокринология</td><td>Endokrinologiýa</td></tr>
-            <tr data-category-row><td>Эпидемиология</td><td>Epidemiologiýa</td></tr>
+          <tbody data-category-body>
+            <tr>
+              <td colspan="3" style="text-align: center">Загружаем направления...</td>
+            </tr>
           </tbody>
         </table>
       </div>

--- a/scripts.js
+++ b/scripts.js
@@ -94,7 +94,75 @@ const UI_TEXTS = {
   },
 };
 
+const CATEGORY_FALLBACK = [
+  { ru: "Акушерство и Гинекология", tm: "Akuşerçilik we Ginekologiýa" },
+  { ru: "Анатомия", tm: "Anatomiýa" },
+  { ru: "Ангиография", tm: "Angiografiýa" },
+  { ru: "Английский язык", tm: "Iňlis dili" },
+  { ru: "Анестезиология", tm: "Anesteziologiýa" },
+  { ru: "Биохимия", tm: "Biohimiýa" },
+  { ru: "Внутренние болезни", tm: "Iç keseller" },
+  { ru: "Военно-полевая терапия", tm: "Harby-meýdan terapiýasy" },
+  { ru: "Военно-полевая хирургия", tm: "Harby-meýdan hirurgiýasy" },
+  { ru: "Гастроэнтерология", tm: "Gastroenterologiýa" },
+  { ru: "Гематология", tm: "Gematologiýa" },
+  { ru: "Гигиена", tm: "Gigiýena" },
+  { ru: "Гистология, цитология", tm: "Gistologiýa, sitologiýa" },
+  { ru: "Детская хирургия", tm: "Çaga hirurgiýasy" },
+  { ru: "Диетология", tm: "Dietologiýa" },
+  { ru: "Инфекционные болезни", tm: "Ýokanç keseller" },
+  { ru: "Инфекционные болезни детей", tm: "Çaga ýokanç keselleri" },
+  { ru: "История медицины", tm: "Lukmançylyk taryhy" },
+  { ru: "Кардиология", tm: "Kardiologiýa" },
+  { ru: "Кардиохирургия", tm: "Kardiohirurgiýa" },
+  { ru: "Клиническая лаборатория", tm: "Kliniki laboratoriýa" },
+  { ru: "Кожные и венерические болезни", tm: "Deri we weneriki keseller" },
+  { ru: "Компьютерная томография", tm: "Kompýuter tomografiýasy" },
+  { ru: "Латинский язык и медицинская терминология", tm: "Latin dili we lukmançylyk terminologiýasy" },
+  { ru: "Лечебная физкультура", tm: "Bejeriş beden terbiyesi" },
+  { ru: "Магнитно-резонансная томография", tm: "Magnit rezonans tomografiýasy" },
+  { ru: "Медицинская биология", tm: "Lukmançylyk biologiýasy" },
+  { ru: "Медицинская генетика", tm: "Lukmançylyk genetikasy" },
+  { ru: "Медицинская и биологическая физика", tm: "Lukmançylyk we biologik fizika" },
+  { ru: "Медицинская иммунология", tm: "Lukmançylyk immunologiýasy" },
+  { ru: "Микробиология", tm: "Mikrobiologiýa" },
+  { ru: "Наркология", tm: "Narkologiýa" },
+  { ru: "Неврология", tm: "Newrologiýa" },
+  { ru: "Нейрохирургия", tm: "Neýrohirurgiýa" },
+  { ru: "Неонатология", tm: "Neonatologiýa" },
+  { ru: "Общая и медицинская химия", tm: "Umumy we lukmançylyk himiýasy" },
+  { ru: "Общая и неорганическая химия", tm: "Umumy we organiki däl himiýa" },
+  { ru: "Онкология", tm: "Onkologiýa" },
+  { ru: "Ортопедия и травматология", tm: "Ortopediýa we trawmatologiýa" },
+  { ru: "Отоларингология", tm: "Otolaringologiýa" },
+  { ru: "Офтальмология", tm: "Oftalmologiýa" },
+  { ru: "Патологическая анатомия", tm: "Patologik anatomiýa" },
+  { ru: "Педиатрия", tm: "Pediatriýa" },
+  { ru: "Пластическая хирургия", tm: "Plastiki hirurgiýa" },
+  { ru: "Психиатрия", tm: "Psihiatriýa" },
+  { ru: "Психология", tm: "Psihologiýa" },
+  { ru: "Пульмонология", tm: "Pulmonologiýa" },
+  { ru: "Радиология", tm: "Radiologiýa" },
+  { ru: "Сердечно-сосудистая хирургия", tm: "Ýürek-damar hirurgiýasy" },
+  { ru: "Сестринское дело", tm: "Şepagat uýasy işi" },
+  { ru: "Судебная медицина", tm: "Kazyýet lukmançylygy" },
+  { ru: "Стоматология", tm: "Stomatologiýa" },
+  { ru: "Терапия", tm: "Terapia" },
+  { ru: "Травматология", tm: "Trawmatologiýa" },
+  { ru: "Ультразвуковая диагностика", tm: "Ultrases barlagy" },
+  { ru: "Фармакология", tm: "Farmakologiýa" },
+  { ru: "Физиология", tm: "Fiziologiýa" },
+  { ru: "Фтизиатрия", tm: "Ftiziatriýa" },
+  { ru: "Хирургия", tm: "Hirurgiýa" },
+  { ru: "Электрокардиография", tm: "Elektrokardiografiýa" },
+  { ru: "Эндокринология", tm: "Endokrinologiýa" },
+  { ru: "Эпидемиология", tm: "Epidemiologiýa" },
+];
+
 const accentPattern = /[\u0300-\u036f]/g;
+const categoryTranslationMap = new Map(
+  CATEGORY_FALLBACK.map((entry) => [normalizeSearchValue(entry.ru), entry.tm])
+);
 
 const bookSearchState = {
   tableBody: null,
@@ -929,41 +997,189 @@ function applyBookFilters() {
   renderBookCards(cardEntries, hasActiveFilter);
 }
 
+function translateSpecialty(value) {
+  if (!value) return "";
+  return categoryTranslationMap.get(normalizeSearchValue(value)) || value;
+}
+
+async function fetchSpecialtiesFromApi(apiBase) {
+  if (!apiBase) {
+    return [];
+  }
+  try {
+    const response = await fetch(`${apiBase}/specialties`);
+    if (!response.ok) {
+      return [];
+    }
+    const payload = await response.json();
+    const items = Array.isArray(payload?.specialties) ? payload.specialties : [];
+    return items
+      .map((item) => {
+        const ru = item?.name?.toString().trim();
+        if (!ru) return null;
+        return {
+          ru,
+          tm: translateSpecialty(ru),
+          count: Number(item.count) || 0,
+        };
+      })
+      .filter(Boolean);
+  } catch (error) {
+    console.warn("Не удалось загрузить специальности из API", error?.message);
+    return [];
+  }
+}
+
+async function fetchBooksFromApi(apiBase) {
+  if (!apiBase) {
+    return [];
+  }
+  try {
+    const response = await fetch(`${apiBase}/books`);
+    if (!response.ok) {
+      return [];
+    }
+    const payload = await response.json();
+    const books = Array.isArray(payload?.books) ? payload.books : [];
+    return books;
+  } catch (error) {
+    console.warn("Не удалось загрузить книги из API", error?.message);
+    return [];
+  }
+}
+
+async function fetchBooksFromJson() {
+  try {
+    const response = await fetch("data/books.json");
+    if (!response.ok) {
+      return [];
+    }
+    const payload = await response.json();
+    if (Array.isArray(payload)) {
+      return payload;
+    }
+    if (Array.isArray(payload?.books)) {
+      return payload.books;
+    }
+  } catch (error) {
+    console.warn("Не удалось загрузить книги из JSON", error?.message);
+  }
+  return [];
+}
+
+function buildCategoriesFromBooks(books = []) {
+  const specialties = new Map();
+  books.forEach((book) => {
+    const specialty = book?.specialty?.toString().trim();
+    if (!specialty) return;
+    const key = normalizeSearchValue(specialty);
+    const existing =
+      specialties.get(key) || {
+        ru: specialty,
+        tm: translateSpecialty(specialty),
+        count: 0,
+      };
+    existing.count += 1;
+    specialties.set(key, existing);
+  });
+
+  return Array.from(specialties.values()).sort((a, b) =>
+    a.ru.localeCompare(b.ru, "ru", { sensitivity: "accent" })
+  );
+}
+
+async function loadCategoryList() {
+  const apiBase = resolveApiBase(document.body?.dataset.apiBase);
+  const fromApi = await fetchSpecialtiesFromApi(apiBase);
+  if (fromApi.length) {
+    return fromApi;
+  }
+
+  const apiBooks = await fetchBooksFromApi(apiBase);
+  const apiCategories = buildCategoriesFromBooks(apiBooks);
+  if (apiCategories.length) {
+    return apiCategories;
+  }
+
+  const jsonBooks = await fetchBooksFromJson();
+  const jsonCategories = buildCategoriesFromBooks(jsonBooks);
+  if (jsonCategories.length) {
+    return jsonCategories;
+  }
+
+  return CATEGORY_FALLBACK.map((item) => ({ ...item, count: 0 }));
+}
+
 function initCategoryFilter() {
   const searchInput = document.getElementById("category-search");
-  const rows = Array.from(document.querySelectorAll("[data-category-row]"));
-  if (!searchInput || !rows.length) {
+  const tableBody = document.querySelector("[data-category-body]");
+  if (!searchInput || !tableBody) {
     return;
   }
-  const counter = document.getElementById("category-count");
-  const total = rows.length;
 
-  const updateCount = (visible) => {
-    if (!counter) {
+  const counter = document.getElementById("category-count");
+  let categories = [];
+
+  const updateCount = (visible, total) => {
+    if (!counter) return;
+    counter.textContent = `${visible} / ${total}`;
+  };
+
+  const renderCategories = (items) => {
+    tableBody.innerHTML = "";
+    if (!items.length) {
+      const row = document.createElement("tr");
+      const cell = document.createElement("td");
+      cell.colSpan = 3;
+      cell.style.textAlign = "center";
+      cell.textContent = "Направления не найдены";
+      row.appendChild(cell);
+      tableBody.appendChild(row);
+      updateCount(0, 0);
       return;
     }
-    counter.textContent = `${visible} / ${total}`;
+
+    items.forEach((item) => {
+      const row = document.createElement("tr");
+      row.dataset.searchValue = normalizeSearchValue(`${item.ru} ${item.tm}`);
+
+      const ruCell = document.createElement("td");
+      ruCell.textContent = item.ru;
+      const tmCell = document.createElement("td");
+      tmCell.textContent = item.tm;
+      const countCell = document.createElement("td");
+      countCell.textContent = item.count ? String(item.count) : "—";
+
+      row.appendChild(ruCell);
+      row.appendChild(tmCell);
+      row.appendChild(countCell);
+      tableBody.appendChild(row);
+    });
+
+    updateCount(items.length, items.length);
   };
 
   const filterRows = () => {
     const query = normalizeSearchValue(searchInput.value);
     let visible = 0;
-    rows.forEach((row) => {
-      if (!row.dataset.searchValue) {
-        row.dataset.searchValue = normalizeSearchValue(row.textContent || "");
-      }
-      const matches = !query || row.dataset.searchValue.includes(query);
+    tableBody.querySelectorAll("tr").forEach((row) => {
+      const matches = !query || row.dataset.searchValue?.includes(query);
       row.hidden = !matches;
       if (matches) {
         visible += 1;
       }
     });
-    updateCount(visible);
+    updateCount(visible, categories.length);
   };
 
   const debouncedFilter = debounce(filterRows, 120);
   searchInput.addEventListener("input", debouncedFilter);
-  filterRows();
+
+  loadCategoryList().then((items) => {
+    categories = items;
+    renderCategories(items);
+    filterRows();
+  });
 }
 
 function updateBookStatus(visibleRows) {

--- a/server.js
+++ b/server.js
@@ -411,11 +411,39 @@ const loadBooksFromStore = async () => {
   return createFileBookStore().listBooks();
 };
 
+const buildSpecialtyIndex = (books = []) => {
+  const specialties = new Map();
+
+  books.forEach((book) => {
+    const specialty = book?.specialty?.toString().trim();
+    if (!specialty) {
+      return;
+    }
+    const key = specialty.toLowerCase();
+    const entry = specialties.get(key) || { name: specialty, count: 0 };
+    entry.count += 1;
+    specialties.set(key, entry);
+  });
+
+  return Array.from(specialties.values()).sort((a, b) =>
+    a.name.localeCompare(b.name, "ru", { sensitivity: "accent" })
+  );
+};
+
 app.get(
   "/books",
   asyncHandler(async (req, res) => {
     const books = await loadBooksFromStore();
     res.json({ books });
+  })
+);
+
+app.get(
+  "/specialties",
+  asyncHandler(async (req, res) => {
+    const books = await loadBooksFromStore();
+    const specialties = buildSpecialtyIndex(books);
+    res.json({ specialties });
   })
 );
 


### PR DESCRIPTION
## Summary
- add an API endpoint that exposes specialties derived from the catalog data
- build the categories table dynamically from API/JSON/books data with fallback translations and counts
- update the categories page markup to point at the API base and show a new count column

## Testing
- node --check scripts.js

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e0dd7cb28832990ad1d5dacd227fc)