### PR TITLE
Handle zero specialty counts

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -1148,7 +1148,9 @@ function initCategoryFilter() {
       const tmCell = document.createElement("td");
       tmCell.textContent = item.tm;
       const countCell = document.createElement("td");
-      countCell.textContent = item.count ? String(item.count) : "—";
+      const countValue =
+        Number.isFinite(item.count) && item.count >= 0 ? item.count : "—";
+      countCell.textContent = String(countValue);
 
       row.appendChild(ruCell);
       row.appendChild(tmCell);


### PR DESCRIPTION
## Summary
- ensure category count column displays 0 instead of a dash for zero-count specialties

## Testing
- not run


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e112245148329b091d54e0935b1d8)