### PR TITLE
Handle category list load failures and remove localhost API base

### DIFF
--- a/BookCategory.html
+++ b/BookCategory.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="manifest" href="manifest.webmanifest">
 </head>
-<body data-api-base="http://localhost:5000">
+<body>
   <header class="site-header">
     <div class="site-header__brand">
       <p class="eyebrow lang" data-lang="ru">Категории библиотеки</p>

--- a/scripts.js
+++ b/scripts.js
@@ -1177,11 +1177,18 @@ function initCategoryFilter() {
   const debouncedFilter = debounce(filterRows, 120);
   searchInput.addEventListener("input", debouncedFilter);
 
-  loadCategoryList().then((items) => {
-    categories = items;
-    renderCategories(items);
-    filterRows();
-  });
+  loadCategoryList()
+    .then((items) => {
+      categories = items;
+      renderCategories(items);
+      filterRows();
+    })
+    .catch((error) => {
+      console.error("Не удалось загрузить направления", error);
+      categories = CATEGORY_FALLBACK.map((item) => ({ ...item, count: 0 }));
+      renderCategories(categories);
+      filterRows();
+    });
 }
 
 function updateBookStatus(visibleRows) {


### PR DESCRIPTION
## Summary
- remove the localhost API base override from the categories page to avoid blocked requests
- add error handling for the category loader so the fallback list renders even when API requests fail

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e123e4e848329b2de9ab15110e626)