### PR TITLE
Avoid API calls on GitHub Pages

### DIFF
--- a/BookCategory.html
+++ b/BookCategory.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="manifest" href="manifest.webmanifest">
 </head>
-<body data-api-base="http://localhost:5000">
+<body>
   <header class="site-header">
     <div class="site-header__brand">
       <p class="eyebrow lang" data-lang="ru">Категории библиотеки</p>

--- a/scripts.js
+++ b/scripts.js
@@ -1177,11 +1177,18 @@ function initCategoryFilter() {
   const debouncedFilter = debounce(filterRows, 120);
   searchInput.addEventListener("input", debouncedFilter);
 
-  loadCategoryList().then((items) => {
-    categories = items;
-    renderCategories(items);
-    filterRows();
-  });
+  loadCategoryList()
+    .then((items) => {
+      categories = items;
+      renderCategories(items);
+      filterRows();
+    })
+    .catch((error) => {
+      console.error("Не удалось загрузить направления", error);
+      categories = CATEGORY_FALLBACK.map((item) => ({ ...item, count: 0 }));
+      renderCategories(categories);
+      filterRows();
+    });
 }
 
 function updateBookStatus(visibleRows) {
@@ -1403,6 +1410,10 @@ function resolveApiBase(attributeBase = "") {
   const params = new URLSearchParams(window.location.search);
   const overrideBase = params.get("apiBase");
   let base = (overrideBase || attributeBase || "").trim();
+
+  if (window.location.hostname.endsWith("github.io")) {
+    return "";
+  }
 
   if (!base) {
     base = window.location.origin;


### PR DESCRIPTION
## Summary
- skip resolving an API base when running on GitHub Pages to prevent 404 requests for categories
- allow the category loader to fall back immediately to bundled data instead of hitting missing endpoints

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e123e4e848329b2de9ab15110e626)