### PR TITLE
Show book totals on categories page

### DIFF
--- a/BookCategory.html
+++ b/BookCategory.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="manifest" href="manifest.webmanifest">
 </head>
-<body data-api-base="http://localhost:5000">
+<body>
   <header class="site-header">
     <div class="site-header__brand">
       <p class="eyebrow lang" data-lang="ru">Категории библиотеки</p>


### PR DESCRIPTION
## Summary
- display the available book count on the category page using API or bundled catalog data
- avoid showing misleading zero counts when only the fallback category list is available
- reuse the resolved API base for loading both categories and book totals

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691e123e4e848329b2de9ab15110e626)