### PR TITLE
Add recovery and resend email flows

### DIFF
--- a/auth.html
+++ b/auth.html
@@ -184,6 +184,65 @@
             border-color: #f87171;
             color: #b91c1c;
         }
+        .support-links {
+            display: flex;
+            justify-content: space-between;
+            gap: 0.75rem;
+            margin-bottom: 0.75rem;
+        }
+        .link-button {
+            width: auto;
+            padding: 0.35rem 0.5rem;
+            background: transparent;
+            border: none;
+            color: #2563eb;
+            font-weight: 600;
+            cursor: pointer;
+        }
+        .link-button:hover {
+            text-decoration: underline;
+        }
+        .modal {
+            position: fixed;
+            inset: 0;
+            background: rgba(15, 23, 42, 0.45);
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            padding: 1rem;
+            z-index: 1000;
+        }
+        .modal[hidden] {
+            display: none;
+        }
+        .modal__dialog {
+            background: #fff;
+            width: min(420px, 100%);
+            border-radius: 20px;
+            padding: 1.5rem;
+            position: relative;
+            box-shadow: 0 12px 45px rgba(15, 23, 42, 0.25);
+        }
+        .modal__close {
+            position: absolute;
+            top: 10px;
+            right: 12px;
+            background: transparent;
+            border: none;
+            font-size: 1.5rem;
+            line-height: 1;
+            cursor: pointer;
+            color: #0f172a;
+        }
+        .modal__title {
+            margin-top: 0;
+            margin-bottom: 0.25rem;
+        }
+        .modal__description {
+            margin-top: 0;
+            color: #475569;
+            font-size: 0.95rem;
+        }
         .session-state {
             text-align: center;
             margin-top: 1.5rem;
@@ -232,6 +291,10 @@
                 <button type="button" class="password-toggle" data-target="login-password">Показать пароль</button>
             </div>
             <button type="submit" id="login">Войти</button>
+            <div class="support-links">
+                <button type="button" class="link-button" id="forgotPasswordTrigger">Забыли пароль?</button>
+                <button type="button" class="link-button" id="resendEmailTrigger">Отправить письмо повторно</button>
+            </div>
             <div class="divider"><span>или</span></div>
             <div class="provider-card">
                 <h2>Вход через Google</h2>
@@ -244,6 +307,32 @@
         <div class="session-state">
             <p id="sessionStatus" class="message" aria-live="polite"></p>
             <button id="logout" type="button" hidden>Выйти</button>
+        </div>
+    </div>
+
+    <div class="modal" id="forgotPasswordModal" hidden>
+        <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="forgotPasswordTitle">
+            <button type="button" class="modal__close" aria-label="Закрыть" data-modal-close>&times;</button>
+            <h2 class="modal__title" id="forgotPasswordTitle">Восстановление пароля</h2>
+            <p class="modal__description">Укажите email, чтобы получить ссылку для смены пароля.</p>
+            <form id="forgotPasswordForm">
+                <input type="email" id="forgot-password-email" placeholder="Ваш email" autocomplete="email" required>
+                <button type="submit" id="forgot-password-submit">Отправить ссылку</button>
+                <p id="forgotPasswordMessage" class="message" aria-live="polite"></p>
+            </form>
+        </div>
+    </div>
+
+    <div class="modal" id="resendVerificationModal" hidden>
+        <div class="modal__dialog" role="dialog" aria-modal="true" aria-labelledby="resendVerificationTitle">
+            <button type="button" class="modal__close" aria-label="Закрыть" data-modal-close>&times;</button>
+            <h2 class="modal__title" id="resendVerificationTitle">Отправить письмо повторно</h2>
+            <p class="modal__description">Проверьте и введите адрес, чтобы мы снова выслали письмо.</p>
+            <form id="resendVerificationForm">
+                <input type="email" id="resend-email" placeholder="Ваш email" autocomplete="email" required>
+                <button type="submit" id="resend-email-submit">Выслать письмо</button>
+                <p id="resendEmailMessage" class="message" aria-live="polite"></p>
+            </form>
         </div>
     </div>
     <script


### PR DESCRIPTION
## Summary
- add password recovery and resend-email links with supporting modals and styling on the auth page
- wire modal forms to new client-side handlers that call password reset and email resend endpoints with status messages
- add server endpoints for requesting password resets and resending messages under shared rate limiting and logging

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69228644b51083299e1158dc4c9735e1)