### PR TITLE
Improve accessibility feedback and shortcuts

### DIFF
--- a/index.html
+++ b/index.html
@@ -47,10 +47,11 @@
         <span class="lang" data-lang="en">Download app</span>
         <span class="lang" data-lang="tm">Programmany ýükläň</span>
       </button>
-      <button id="auth-open-button" class="button button--outline auth-open-button" type="button">
+      <button id="auth-open-button" class="button button--outline auth-open-button" type="button" accesskey="a" aria-describedby="auth-hotkey">
         <span class="lang" data-lang="ru">Регистрация / вход</span>
         <span class="lang" data-lang="en">Sign up / Sign in</span>
         <span class="lang" data-lang="tm">Hasaba al / Içeri gir</span>
+        <span id="auth-hotkey" class="hotkey-hint" aria-hidden="true">Alt+Shift+A</span>
       </button>
     </div>
     <nav class="site-nav" aria-label="Основная навигация">
@@ -311,11 +312,13 @@
           <span class="lang" data-lang="tm">Habar</span>
           <textarea id="message" name="message" required></textarea>
         </label>
-        <button class="button button--primary" type="submit">
+        <button class="button button--primary" type="submit" accesskey="s" aria-describedby="contact-hotkey">
           <span class="lang" data-lang="ru">Отправить</span>
           <span class="lang" data-lang="en">Send</span>
           <span class="lang" data-lang="tm">Ugrat</span>
+          <span id="contact-hotkey" class="hotkey-hint" aria-hidden="true">Alt+Shift+S</span>
         </button>
+        <p id="contact-status" class="auth-status" role="status" aria-live="polite"></p>
       </form>
       <div class="contact__info">
         <a href="tel:+99362234094">+993 62 23 40 94</a>
@@ -376,7 +379,7 @@
             <input type="password" id="register-password" placeholder="Пароль (мин. 6 символов)" minlength="6" autocomplete="new-password" required>
             <label class="visually-hidden" for="register-confirm">Подтверждение пароля</label>
             <input type="password" id="register-confirm" placeholder="Повторите пароль" minlength="6" autocomplete="new-password" required>
-            <button id="register-button" type="submit">Зарегистрироваться</button>
+            <button id="register-button" type="submit" accesskey="r" aria-describedby="register-hotkey">Зарегистрироваться <span id="register-hotkey" class="hotkey-hint" aria-hidden="true">Alt+Shift+R</span></button>
             <p id="register-status" class="auth-status" role="status" aria-live="polite"></p>
           </form>
           <form id="login-form" class="auth-panel" role="tabpanel" aria-labelledby="login-tab" hidden>
@@ -385,7 +388,7 @@
             <input type="email" id="login-email" placeholder="Email" autocomplete="email" required>
             <label class="visually-hidden" for="login-password">Пароль</label>
             <input type="password" id="login-password" placeholder="Пароль" minlength="6" autocomplete="current-password" required>
-            <button id="login-button" type="submit">Войти</button>
+            <button id="login-button" type="submit" accesskey="l" aria-describedby="login-hotkey">Войти <span id="login-hotkey" class="hotkey-hint" aria-hidden="true">Alt+Shift+L</span></button>
             <div class="auth-divider"><span>или</span></div>
             <div class="auth-provider-card">
               <p class="auth-provider-card__title">Используйте учетную запись Google</p>

--- a/scripts.js
+++ b/scripts.js
@@ -409,8 +409,14 @@ function initRegistrationForm(apiBase, modalControls = {}) {
     const password = passwordInput.value.trim();
     const confirmPassword = confirmInput.value.trim();
 
+    updateInputValidity(emailInput, true, statusElement);
+    updateInputValidity(passwordInput, true, statusElement);
+    updateInputValidity(confirmInput, true, statusElement);
+
     if (!isEmailValid(email)) {
       setStatusMessage(statusElement, "Введите корректный email", "error");
+      updateInputValidity(emailInput, false, statusElement);
+      emailInput.focus();
       return;
     }
 
@@ -420,11 +426,15 @@ function initRegistrationForm(apiBase, modalControls = {}) {
         "Пароль должен содержать минимум 6 символов",
         "error"
       );
+      updateInputValidity(passwordInput, false, statusElement);
+      passwordInput.focus();
       return;
     }
 
     if (password !== confirmPassword) {
       setStatusMessage(statusElement, "Пароли не совпадают", "error");
+      updateInputValidity(confirmInput, false, statusElement);
+      confirmInput.focus();
       return;
     }
 
@@ -559,8 +569,13 @@ function initLoginForm(apiBase, modalControls = {}) {
     const email = emailInput.value.trim();
     const password = passwordInput.value.trim();
 
+    updateInputValidity(emailInput, true, statusElement);
+    updateInputValidity(passwordInput, true, statusElement);
+
     if (!isEmailValid(email)) {
       setStatusMessage(statusElement, "Введите корректный email", "error");
+      updateInputValidity(emailInput, false, statusElement);
+      emailInput.focus();
       return;
     }
 
@@ -570,6 +585,8 @@ function initLoginForm(apiBase, modalControls = {}) {
         "Пароль должен содержать минимум 6 символов",
         "error"
       );
+      updateInputValidity(passwordInput, false, statusElement);
+      passwordInput.focus();
       return;
     }
 
@@ -1313,10 +1330,33 @@ function setStatusMessage(element, message, state) {
   if (!element) {
     return;
   }
+
   element.textContent = message || "";
   element.classList.remove("success", "error", "pending");
   if (state) {
     element.classList.add(state);
+  }
+
+  element.setAttribute("role", "status");
+  element.setAttribute("aria-live", "polite");
+}
+
+function updateInputValidity(input, isValid, statusElement) {
+  if (!input) {
+    return;
+  }
+
+  if (isValid) {
+    input.removeAttribute("aria-invalid");
+    if (statusElement?.id && input.getAttribute("aria-describedby") === statusElement.id) {
+      input.removeAttribute("aria-describedby");
+    }
+    return;
+  }
+
+  input.setAttribute("aria-invalid", "true");
+  if (statusElement?.id) {
+    input.setAttribute("aria-describedby", statusElement.id);
   }
 }
 
@@ -1635,8 +1675,34 @@ window.sendMail = () => {
   const name = document.getElementById("name");
   const email = document.getElementById("email");
   const message = document.getElementById("message");
+  const statusElement = document.getElementById("contact-status");
 
   if (!name || !email || !message) {
+    return;
+  }
+
+  updateInputValidity(name, true, statusElement);
+  updateInputValidity(email, true, statusElement);
+  updateInputValidity(message, true, statusElement);
+
+  if (!name.value.trim()) {
+    setStatusMessage(statusElement, "Введите ваше имя", "error");
+    updateInputValidity(name, false, statusElement);
+    name.focus();
+    return;
+  }
+
+  if (!isEmailValid(email.value.trim())) {
+    setStatusMessage(statusElement, "Введите корректный email", "error");
+    updateInputValidity(email, false, statusElement);
+    email.focus();
+    return;
+  }
+
+  if (!message.value.trim()) {
+    setStatusMessage(statusElement, "Введите сообщение", "error");
+    updateInputValidity(message, false, statusElement);
+    message.focus();
     return;
   }
 
@@ -1648,6 +1714,9 @@ window.sendMail = () => {
     email.value +
     "%0D%0AСообщение: " +
     message.value;
+
+  setStatusMessage(statusElement, "Открываем почтовый клиент...", "pending");
   window.location.href =
     "mailto:tdlipfmdm@gmail.com?subject=" + subject + "&body=" + body;
+  setStatusMessage(statusElement, "Черновик письма создан", "success");
 };

--- a/styles.css
+++ b/styles.css
@@ -548,6 +548,24 @@ main {
   color: var(--muted);
 }
 
+.auth-status.success {
+  color: #22c55e;
+}
+
+.auth-status.error {
+  color: #f87171;
+}
+
+.auth-status.pending {
+  color: #e0b100;
+}
+
+.hotkey-hint {
+  font-size: 0.85em;
+  color: #8a93a5;
+  margin-left: 8px;
+}
+
 .auth-divider {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- add aria-invalid/aria-describedby handling with focus management for auth and contact form validation
- ensure status messages announce updates via role="status" and provide inline feedback for contact form
- expose keyboard shortcuts with on-screen hints for key actions like auth and message send

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69228a9f24cc8329a977c25378ccf3a8)