### PR TITLE
Redesign landing page with BooksMed-inspired structure

### DIFF
--- a/index.html
+++ b/index.html
@@ -56,14 +56,24 @@
     </div>
     <nav class="site-nav" aria-label="Основная навигация">
       <a href="#hero">
-        <span class="lang" data-lang="ru">Обзор</span>
-        <span class="lang" data-lang="en">Overview</span>
-        <span class="lang" data-lang="tm">Gysgaça</span>
+        <span class="lang" data-lang="ru">Главная</span>
+        <span class="lang" data-lang="en">Home</span>
+        <span class="lang" data-lang="tm">Baş sahypa</span>
       </a>
-      <a href="#features">
-        <span class="lang" data-lang="ru">Функции</span>
-        <span class="lang" data-lang="en">Features</span>
+      <a href="#solutions">
+        <span class="lang" data-lang="ru">Решения</span>
+        <span class="lang" data-lang="en">Solutions</span>
         <span class="lang" data-lang="tm">Mümkinçilikler</span>
+      </a>
+      <a href="#catalog">
+        <span class="lang" data-lang="ru">Каталог</span>
+        <span class="lang" data-lang="en">Catalog</span>
+        <span class="lang" data-lang="tm">Katalog</span>
+      </a>
+      <a href="#platform">
+        <span class="lang" data-lang="ru">Платформа</span>
+        <span class="lang" data-lang="en">Platform</span>
+        <span class="lang" data-lang="tm">Platforma</span>
       </a>
       <a href="#gallery">
         <span class="lang" data-lang="ru">Галерея</span>
@@ -81,9 +91,9 @@
         <span class="lang" data-lang="tm">Kategoriýalar</span>
       </a>
       <a href="book.html">
-        <span class="lang" data-lang="ru">Каталог</span>
-        <span class="lang" data-lang="en">Catalog</span>
-        <span class="lang" data-lang="tm">Katalog</span>
+        <span class="lang" data-lang="ru">Каталог книг</span>
+        <span class="lang" data-lang="en">Book list</span>
+        <span class="lang" data-lang="tm">Kitap sanawy</span>
       </a>
       <a
         href="https://sites.google.com/view/lukmanylyksanlykitaphanasy/ba%C5%9F-sahypa"
@@ -101,44 +111,49 @@
   <main>
     <section id="hero" class="hero">
       <div class="hero__content">
-        <p class="hero__eyebrow lang" data-lang="ru">69 направлений, 1000+ книг, офлайн‑режим</p>
-        <p class="hero__eyebrow lang" data-lang="en">69 specialties, 1K+ books, offline mode</p>
-        <p class="hero__eyebrow lang" data-lang="tm">69 ugur, 1000+ kitap, oflaýn elýeterlik</p>
-        <h2 class="hero__title lang" data-lang="ru">Ultra‑modern библиотека с поиском 2× быстрее</h2>
-        <h2 class="hero__title lang" data-lang="en">Ultra‑modern library with 2× faster search</h2>
-        <h2 class="hero__title lang" data-lang="tm">2 gezek çalt gözlegli döwrebap kitaphana</h2>
+        <p class="hero__eyebrow lang" data-lang="ru">Структура и логика BooksMed теперь в MedLibrary</p>
+        <p class="hero__eyebrow lang" data-lang="en">BooksMed-inspired structure now inside MedLibrary</p>
+        <p class="hero__eyebrow lang" data-lang="tm">BooksMed logikasy bilen täzelenen MedLibrary</p>
+        <h2 class="hero__title lang" data-lang="ru">Единая медицинская библиотека для обучения и практики</h2>
+        <h2 class="hero__title lang" data-lang="en">A single medical library for learning and practice</h2>
+        <h2 class="hero__title lang" data-lang="tm">Okuw we amaly işler üçin bir platforma</h2>
         <p class="hero__text lang" data-lang="ru">
-          Новая архитектура кода ускоряет загрузку страниц, а адаптивный интерфейс подстраивается под мобильные и настольные
-          устройства. Каталог доступен даже без интернета и теперь устанавливается как полноценное PWA‑приложение.
+          Быстрый поиск по 1000+ книгам, готовые категории и офлайн‑режим собраны в одном окне. Архитектура повторяет
+          привычную навигацию BooksMed, но дополнена PWA, авторизацией и мгновенными фильтрами.
         </p>
         <p class="hero__text lang" data-lang="en">
-          The refreshed architecture ships pages faster and adapts to any device. The catalog now works offline and can be installed
-          as a full PWA app.
+          Search across 1K+ books with curated categories and offline access. The layout mirrors the familiar BooksMed logic and
+          adds PWA, authentication, and instant filters.
         </p>
         <p class="hero__text lang" data-lang="tm">
-          Täzelenen arhitektura sahypalary has çalt ýükläp, ähli enjamlara uýgunlaşýar. Katalog internetsiz işleýär we PWA
-          programmasy hökmünde gurnalmaga taýýar.
+          1000+ kitap boýunça çalt gözleg, taýýar kategoriýalar we oflaýn elýeterlik — hemmesi bir penjirede. BooksMed
+          ulgamyna meňzeş gurluşa PWA, awtorizasiýa we derrew filtrler goşuldy.
         </p>
+        <div class="pill-group">
+          <span class="pill">69 направлений</span>
+          <span class="pill">Каталог, категории, поиск</span>
+          <span class="pill">Офлайн и PWA</span>
+        </div>
         <div class="hero__actions">
           <a class="button button--primary" href="book.html">
             <span class="lang" data-lang="ru">Открыть каталог</span>
             <span class="lang" data-lang="en">Open catalog</span>
             <span class="lang" data-lang="tm">Katalogy aç</span>
           </a>
-          <button class="button button--ghost" type="button" data-install-trigger data-install-sticky>
-            <span class="lang" data-lang="ru">Скачать приложение</span>
-            <span class="lang" data-lang="en">Download app</span>
-            <span class="lang" data-lang="tm">Programmany ýükläň</span>
+          <a class="button button--ghost" href="BookCategory.html">
+            <span class="lang" data-lang="ru">Категории BooksMed</span>
+            <span class="lang" data-lang="en">BooksMed-style categories</span>
+            <span class="lang" data-lang="tm">BooksMed kategoriýalary</span>
+          </a>
+          <button class="button button--text" type="button" data-install-trigger data-install-sticky>
+            <span class="lang" data-lang="ru">Установить PWA</span>
+            <span class="lang" data-lang="en">Install PWA</span>
+            <span class="lang" data-lang="tm">PWA gurnamak</span>
           </button>
           <a class="button button--text" href="Book.xlsx" download>
             <span class="lang" data-lang="ru">Каталог в Excel</span>
             <span class="lang" data-lang="en">Catalog in Excel</span>
             <span class="lang" data-lang="tm">Excel katalogy</span>
-          </a>
-          <a class="button button--text" href="data/books.json" download>
-            <span class="lang" data-lang="ru">Каталог в JSON</span>
-            <span class="lang" data-lang="en">Catalog in JSON</span>
-            <span class="lang" data-lang="tm">JSON katalogy</span>
           </a>
         </div>
         <div class="hero__metrics">
@@ -155,98 +170,166 @@
             <p class="metric-card__label lang" data-lang="tm">Lukmançylyk ugurlary</p>
           </article>
           <article class="metric-card">
-            <p class="metric-card__value">2×</p>
-            <p class="metric-card__label lang" data-lang="ru">Быстрее поиск и фильтры</p>
-            <p class="metric-card__label lang" data-lang="en">Faster search & filters</p>
-            <p class="metric-card__label lang" data-lang="tm">Çalt gözleg</p>
+            <p class="metric-card__value">24/7</p>
+            <p class="metric-card__label lang" data-lang="ru">Онлайн и офлайн доступ</p>
+            <p class="metric-card__label lang" data-lang="en">Online + offline access</p>
+            <p class="metric-card__label lang" data-lang="tm">Onlaýn + oflaýn</p>
           </article>
         </div>
       </div>
       <div class="hero__preview" aria-hidden="true">
         <div class="preview-card">
-          <p>Offline&nbsp;PWA</p>
-          <strong>Install MedLibrary</strong>
-          <span>Works on desktop & mobile</span>
+          <p>BooksMed logic</p>
+          <strong>Категории, каталог, поиск</strong>
+          <span>Навигация, как на booksmed.info</span>
         </div>
-        <div class="preview-card">
-          <p>Real covers</p>
-          <strong>Open Library API</strong>
-          <span>Automatic artwork for каждый запрос</span>
+        <div class="preview-card preview-card--image">
+          <img src="1.webp" alt="Каталог MedLibrary" loading="lazy" decoding="async">
+          <div class="preview-card__hint">Открывайте, фильтруйте и скачивайте книги</div>
         </div>
       </div>
     </section>
 
-    <section id="features" class="section">
+    <section id="solutions" class="section">
       <div class="section__head">
-        <p class="eyebrow lang" data-lang="ru">Ключевые возможности</p>
-        <p class="eyebrow lang" data-lang="en">Key capabilities</p>
-        <p class="eyebrow lang" data-lang="tm">Esasy mümkinçilikler</p>
-        <h2 class="section__title lang" data-lang="ru">Умный поиск, фильтры и мульти‑язычность</h2>
-        <h2 class="section__title lang" data-lang="en">Smart search, filters and localization</h2>
-        <h2 class="section__title lang" data-lang="tm">Akylly gözleg we köp dilli interfeýs</h2>
+        <p class="eyebrow lang" data-lang="ru">Структура как в BooksMed</p>
+        <p class="eyebrow lang" data-lang="en">BooksMed-inspired sections</p>
+        <p class="eyebrow lang" data-lang="tm">BooksMed görnüşli bölümler</p>
+        <h2 class="section__title lang" data-lang="ru">Четыре блока: каталог, категории, поиск, контакт</h2>
+        <h2 class="section__title lang" data-lang="en">Four pillars: catalog, categories, search, contact</h2>
+        <h2 class="section__title lang" data-lang="tm">Dört sütün: katalog, kategoriýa, gözleg, habarlaşmak</h2>
         <p class="section__subtitle lang" data-lang="ru">
-          Комбинируйте глобальный поиск, фильтры по колонкам и категориальный словарь. Для офлайн‑режима все кэшируется в
-          браузере и в сервис‑воркере.
+          Повторили привычную логику BooksMed: быстрый вход в каталог, раздел категорий, контекстный поиск и отдельный блок
+          связи. Добавили офлайн, PWA и авторизацию.
         </p>
         <p class="section__subtitle lang" data-lang="en">
-          Mix global search, column filters and the categorized dictionary. Offline mode caches everything in the browser and the
-          service worker.
+          We mirror the familiar BooksMed flow: quick catalog entry, categories hub, contextual search, and a contact section.
+          Offline, PWA, and authentication are built in.
         </p>
         <p class="section__subtitle lang" data-lang="tm">
-          Umumy gözlegi, sütün filtrlerini we kategoriýa sözlügini utgaşdyryň. Oflaýn tertibi üçin maglumatlar brauzerde we
-          hyzmatçy işçisinde keshlenýär.
+          BooksMed logikasyny gaýtaladyl: katalog, kategoriýalar, kontekstli gözleg we habarlaşmak bölümi. Oflaýn, PWA we awtorizasiýa goşuldy.
         </p>
       </div>
       <div class="feature-grid" role="list">
         <article class="feature-card" role="listitem">
-          <div class="feature-icon" aria-hidden="true">⚡</div>
-          <h3>Performance</h3>
-          <p>Ленивая загрузка, оптимизированные таблицы и мини‑кэш ускоряют интерфейс до 2–3×.</p>
+          <div class="feature-icon" aria-hidden="true">📚</div>
+          <h3>Каталог</h3>
+          <p>Мгновенное открытие списка книг с сортировками, карточками и экспортом в Excel/JSON.</p>
         </article>
         <article class="feature-card" role="listitem">
-          <div class="feature-icon" aria-hidden="true">📱</div>
-          <h3>PWA</h3>
-          <p>Установите библиотеку как приложение: сервис‑воркер кэширует страницы и офлайн‑каталог.</p>
+          <div class="feature-icon" aria-hidden="true">🧭</div>
+          <h3>Категории</h3>
+          <p>69 тематических направлений как на BooksMed: от анатомии до хирургии, с быстрым фильтром.</p>
         </article>
         <article class="feature-card" role="listitem">
           <div class="feature-icon" aria-hidden="true">🔍</div>
           <h3>Поиск</h3>
-          <p>Улучшенный движок сопоставляет языки, учитывает диакритику и выводит карточки по категории.</p>
+          <p>Глобальный поиск по всем колонкам каталога с учетом диакритики и подсказками по категориям.</p>
         </article>
         <article class="feature-card" role="listitem">
-          <div class="feature-icon" aria-hidden="true">🖼️</div>
-          <h3>Обложки</h3>
-          <p>Связь с Open Library автоматически подставляет реальные обложки книг без ручного редактирования.</p>
+          <div class="feature-icon" aria-hidden="true">📞</div>
+          <h3>Контакты</h3>
+          <p>Прямая связь с разработчиком: задавайте вопросы, заказывайте добавление книг и интеграции.</p>
         </article>
       </div>
     </section>
 
-    <section class="section section--split" id="smart-search">
+    <section id="catalog" class="section section--split">
       <div>
-        <h2 class="section__title lang" data-lang="ru">Плавные фильтры</h2>
-        <h2 class="section__title lang" data-lang="en">Smooth filters</h2>
-        <h2 class="section__title lang" data-lang="tm">Ýumşak filtrler</h2>
-        <p class="section__subtitle lang" data-lang="ru">Поиск по всем колонкам текстового каталога books.json с подсветкой категорий и выводом карточек.</p>
-        <p class="section__subtitle lang" data-lang="en">Search every books.json column with highlighted categories and rendered cards.</p>
-        <p class="section__subtitle lang" data-lang="tm">books.json faýlyndaky ähli sütünler boýunça gözleg we kategoriýalar üçin kartlar.</p>
+        <h2 class="section__title lang" data-lang="ru">Каталог и категории в знакомой логике</h2>
+        <h2 class="section__title lang" data-lang="en">Catalog and categories with familiar flow</h2>
+        <h2 class="section__title lang" data-lang="tm">Tanyş gurluşly katalog we kategoriýalar</h2>
+        <p class="section__subtitle lang" data-lang="ru">Каталог открывается в один клик, категории вынесены в отдельный раздел, а поиск объединяет оба сценария.</p>
+        <p class="section__subtitle lang" data-lang="en">Open the catalog in one click, explore categories separately, and use unified search across both.</p>
+        <p class="section__subtitle lang" data-lang="tm">Katalogy bir basyş bilen açyň, kategoriýalary aýratyn görüň we birleşdirilen gözlegi ulanyň.</p>
         <ul class="checklist">
-          <li>Дебаунс 160 мс и кеширование запросов</li>
-          <li>Нормализация текста без диакритики</li>
-          <li>Гибридный вывод: таблица + карточки</li>
+          <li>Экспорт каталога в Excel и JSON</li>
+          <li>Фильтрация и карточки по аналогии с BooksMed</li>
+          <li>Подсветка категории и ключевых полей</li>
         </ul>
+        <div class="cta-inline">
+          <a class="button button--primary" href="book.html">Каталог книг</a>
+          <a class="button button--ghost" href="BookCategory.html">Категории</a>
+        </div>
       </div>
       <div class="accent-card">
-        <p class="accent-card__eyebrow">Категории</p>
-        <h3>69 тематик</h3>
-        <p>Поиск по словарю категорий теперь мгновенный и показывает количество совпадений.</p>
-        <a class="button button--primary" href="BookCategory.html">Перейти к категориям</a>
+        <p class="accent-card__eyebrow">Статистика</p>
+        <h3>69 тематик и 1000+ изданий</h3>
+        <p>От анатомии и хирургии до эпидемиологии и генетики — вся структура перенесена в MedLibrary.</p>
+        <div class="accent-card__tags">
+          <span class="pill">Анатомия</span>
+          <span class="pill">Кардиология</span>
+          <span class="pill">Педиатрия</span>
+          <span class="pill">Хирургия</span>
+        </div>
       </div>
+    </section>
+
+    <section id="platform" class="section platform">
+      <div class="section__head">
+        <p class="eyebrow">Platforma</p>
+        <h2>MedLibrary как полнофункциональный сервис</h2>
+        <p class="section__subtitle">Архитектура сайта повторяет структуру BooksMed, но добавляет офлайн-кэш, авторизацию и возможность установки.</p>
+      </div>
+      <div class="platform__grid">
+        <article class="platform__card">
+          <div class="feature-icon" aria-hidden="true">⚡</div>
+          <h3>Производительность</h3>
+          <p>Ленивая загрузка и оптимизация таблиц удерживают скорость на уровне 2–3× даже при большом каталоге.</p>
+        </article>
+        <article class="platform__card">
+          <div class="feature-icon" aria-hidden="true">📱</div>
+          <h3>PWA + офлайн</h3>
+          <p>Установите библиотеку как приложение: сервис‑воркер кэширует страницы, категории и файлы каталога.</p>
+        </article>
+        <article class="platform__card">
+          <div class="feature-icon" aria-hidden="true">🔐</div>
+          <h3>Авторизация</h3>
+          <p>Регистрация, вход и Google Identity помогают безопасно делиться подборками и сохранять сессии.</p>
+        </article>
+        <article class="platform__card">
+          <div class="feature-icon" aria-hidden="true">🛰️</div>
+          <h3>Интеграции</h3>
+          <p>Подключение внешних сервисов для обложек и аналитики обеспечивает актуальные данные и визуализацию.</p>
+        </article>
+      </div>
+    </section>
+
+    <section class="section steps">
+      <div class="section__head">
+        <p class="eyebrow">Путь пользователя</p>
+        <h2>Простой маршрут, как на BooksMed</h2>
+        <p class="section__subtitle">Повторяем знакомую логику: заходите на главную, переходите в каталог, уточняете поиск и связываетесь при необходимости.</p>
+      </div>
+      <ol class="steps__list">
+        <li>
+          <span class="steps__index">01</span>
+          <div>
+            <h3>Главная</h3>
+            <p>Получите обзор сервиса и сразу выберите нужный раздел — каталог или категории.</p>
+          </div>
+        </li>
+        <li>
+          <span class="steps__index">02</span>
+          <div>
+            <h3>Каталог / категории</h3>
+            <p>Используйте быстрый поиск, фильтры по колонкам и подсветку тематик для точного результата.</p>
+          </div>
+        </li>
+        <li>
+          <span class="steps__index">03</span>
+          <div>
+            <h3>Скачивание и контакт</h3>
+            <p>Экспортируйте Excel/JSON, установите PWA и напишите разработчику, если нужно расширить библиотеку.</p>
+          </div>
+        </li>
+      </ol>
     </section>
 
     <section id="gallery" class="gallery-slider">
       <div class="section__head">
         <p class="eyebrow">Gallery</p>
-        <h2>Интерфейс в действии</h2>
+        <h2>Интерфейс MedLibrary</h2>
       </div>
       <div class="gallery-slider__viewport">
         <div class="slide"><img src="1.webp" alt="Каталог MedLibrary" loading="lazy" decoding="async"></div>
@@ -263,11 +346,11 @@
     <section id="download" class="download">
       <div class="section__head">
         <p class="eyebrow">Install</p>
-        <h2>MedLibrary как приложение</h2>
-        <p>Нажмите кнопку ниже, чтобы установить PWA или скачайте каталог для офлайн‑просмотра.</p>
+        <h2>Скачайте MedLibrary или работайте офлайн</h2>
+        <p>Установите PWA, чтобы повторить опыт BooksMed в формате приложения, или скачайте каталог для локальной работы.</p>
       </div>
       <div class="download__actions">
-        <button class="button button--primary" type="button" data-install-trigger data-install-sticky>Скачать приложение</button>
+        <button class="button button--primary" type="button" data-install-trigger data-install-sticky>Установить приложение</button>
         <a class="button button--ghost" href="data/books.json" download>
           <span class="lang" data-lang="ru">Скачать JSON каталог</span>
           <span class="lang" data-lang="en">Download JSON catalog</span>
@@ -275,9 +358,9 @@
         </a>
       </div>
       <ul class="checklist checklist--inline">
-        <li>Поддержка Android / Windows / macOS</li>
+        <li>Android / Windows / macOS</li>
         <li>Сервис‑воркер с динамическим кэшем</li>
-        <li>Фоновое обновление ресурсов</li>
+        <li>Глобальные и локальные ресурсы офлайн</li>
       </ul>
     </section>
 
@@ -289,9 +372,9 @@
         <h2 class="section__title lang" data-lang="ru">Напишите разработчику</h2>
         <h2 class="section__title lang" data-lang="en">Get in touch</h2>
         <h2 class="section__title lang" data-lang="tm">Habarlaşyň</h2>
-        <p class="section__subtitle lang" data-lang="ru">Ответим на вопросы, добавим новые книги и подключим интеграции.</p>
-        <p class="section__subtitle lang" data-lang="en">Ask for new books, integrations or onboarding support.</p>
-        <p class="section__subtitle lang" data-lang="tm">Täze kitaplar, integrasiýalar ýa-da goldaw barada sorag iberiň.</p>
+        <p class="section__subtitle lang" data-lang="ru">Расскажите, что еще перенести из BooksMed или какие книги добавить.</p>
+        <p class="section__subtitle lang" data-lang="en">Tell us what else to bring from BooksMed or which books to add.</p>
+        <p class="section__subtitle lang" data-lang="tm">BooksMed-dan başga nämeleri goşmak ýa-da haýsy kitaplary goşmak barada ýazyň.</p>
       </div>
       <form class="contact__form" onsubmit="sendMail(); return false;">
         <label class="form-group">

--- a/styles.css
+++ b/styles.css
@@ -841,6 +841,125 @@ main {
   font-size: 0.9rem;
 }
 
+.pill-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(56, 189, 248, 0.08);
+  color: var(--text);
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.preview-card--image {
+  position: relative;
+  overflow: hidden;
+}
+
+.preview-card--image img {
+  width: 100%;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  box-shadow: var(--shadow);
+}
+
+.preview-card__hint {
+  position: absolute;
+  bottom: 0.75rem;
+  left: 0.75rem;
+  right: 0.75rem;
+  padding: 0.6rem 0.9rem;
+  border-radius: 0.75rem;
+  background: rgba(2, 6, 23, 0.85);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  font-weight: 600;
+}
+
+.cta-inline {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+}
+
+.accent-card__tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  margin-top: 0.5rem;
+}
+
+.platform {
+  background: radial-gradient(circle at top left, rgba(56, 189, 248, 0.08), transparent 45%);
+  border-radius: 1.5rem;
+  padding: clamp(2rem, 3vw, 3rem);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  box-shadow: var(--shadow);
+}
+
+.platform__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1rem;
+}
+
+.platform__card {
+  padding: 1rem;
+  border-radius: 1rem;
+  background: rgba(15, 23, 42, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.steps {
+  background: rgba(2, 6, 23, 0.7);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: var(--shadow);
+}
+
+.steps__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.75rem;
+}
+
+.steps__list li {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.85rem;
+  padding: 0.9rem 1rem;
+  border-radius: 1rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(15, 23, 42, 0.7);
+}
+
+.steps__index {
+  font-weight: 800;
+  color: var(--primary);
+  letter-spacing: 0.08em;
+}
+
+.steps h3 {
+  margin: 0;
+}
+
+.steps p {
+  margin: 0.25rem 0 0;
+  color: var(--muted);
+}
+
 .sqlite-placeholder {
   width: 100%;
   padding: 1rem;


### PR DESCRIPTION
## Summary
- reworked landing navigation and hero to follow BooksMed-style flow with catalog, categories, and contact emphasis
- added new catalog, platform, and steps sections describing BooksMed-inspired structure plus updated gallery/download messaging
- introduced new UI styling elements (pills, platform cards, steps layout, preview image hint) for refreshed layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922903282d48329b135c610efd9d08e)