### PR TITLE
Refresh landing page content and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <meta name="theme-color" content="#050b1d">
+  <meta name="theme-color" content="#0b1224">
   <meta
     name="description"
     content="MedLibrary — современная медицинская электронная библиотека с офлайн‑доступом, PWA, быстрым поиском и более чем 1000 книгами."
@@ -25,13 +25,15 @@
     <header class="site-header">
       <div class="container site-header__bar">
         <div class="site-header__brand">
-          <p class="eyebrow lang" data-lang="ru">Цифровая платформа знаний</p>
-          <p class="eyebrow lang" data-lang="en">Digital knowledge platform</p>
-          <p class="eyebrow lang" data-lang="tm">Sanly bilim platformasy</p>
-          <h1 class="site-header__title lang" data-lang="ru">Медицинская электронная библиотека</h1>
-          <h1 class="site-header__title lang" data-lang="en">Medical e-Library</h1>
-          <h1 class="site-header__title lang" data-lang="tm">Elektron lukmançylyk kitaphanasy</h1>
-          <p class="site-header__lead">Интерфейс, построенный по логике booksmed.info: знакомые блоки, четкие акценты, ясная навигация.</p>
+          <p class="eyebrow lang" data-lang="ru">цифровая медицинская библиотека</p>
+          <p class="eyebrow lang" data-lang="en">digital medical library</p>
+          <p class="eyebrow lang" data-lang="tm">sanly lukmançylyk kitaphanasy</p>
+          <h1 class="site-header__title lang" data-lang="ru">MedLibrary</h1>
+          <h1 class="site-header__title lang" data-lang="en">MedLibrary</h1>
+          <h1 class="site-header__title lang" data-lang="tm">MedLibrary</h1>
+          <p class="site-header__lead">
+            Единый каталог, логика BooksMed и PWA-доступ в одном аккуратном интерфейсе.
+          </p>
         </div>
         <div class="site-header__actions">
           <select id="language-select" aria-label="Сменить язык">
@@ -60,56 +62,14 @@
       </div>
       <nav class="site-nav" aria-label="Основная навигация">
         <div class="container site-nav__wrap">
-          <a href="#hero">
-            <span class="lang" data-lang="ru">Главная</span>
-            <span class="lang" data-lang="en">Home</span>
-            <span class="lang" data-lang="tm">Baş sahypa</span>
-          </a>
-          <a href="#solutions">
-            <span class="lang" data-lang="ru">Решения</span>
-            <span class="lang" data-lang="en">Solutions</span>
-            <span class="lang" data-lang="tm">Mümkinçilikler</span>
-          </a>
-          <a href="#catalog">
-            <span class="lang" data-lang="ru">Каталог</span>
-            <span class="lang" data-lang="en">Catalog</span>
-            <span class="lang" data-lang="tm">Katalog</span>
-          </a>
-          <a href="#platform">
-            <span class="lang" data-lang="ru">Платформа</span>
-            <span class="lang" data-lang="en">Platform</span>
-            <span class="lang" data-lang="tm">Platforma</span>
-          </a>
-          <a href="#gallery">
-            <span class="lang" data-lang="ru">Галерея</span>
-            <span class="lang" data-lang="en">Gallery</span>
-            <span class="lang" data-lang="tm">Suratlar</span>
-          </a>
-          <a href="#contact">
-            <span class="lang" data-lang="ru">Контакты</span>
-            <span class="lang" data-lang="en">Contacts</span>
-            <span class="lang" data-lang="tm">Habarlaşyň</span>
-          </a>
-          <a href="BookCategory.html">
-            <span class="lang" data-lang="ru">Категории</span>
-            <span class="lang" data-lang="en">Categories</span>
-            <span class="lang" data-lang="tm">Kategoriýalar</span>
-          </a>
-          <a href="book.html">
-            <span class="lang" data-lang="ru">Каталог книг</span>
-            <span class="lang" data-lang="en">Book list</span>
-            <span class="lang" data-lang="tm">Kitap sanawy</span>
-          </a>
-          <a
-            href="https://sites.google.com/view/lukmanylyksanlykitaphanasy/ba%C5%9F-sahypa"
-            target="_blank"
-            rel="noopener"
-            class="site-nav__external"
-          >
-            <span class="lang" data-lang="ru">Другой сайт</span>
-            <span class="lang" data-lang="en">Alt site</span>
-            <span class="lang" data-lang="tm">Goşmaça sahypa</span>
-          </a>
+          <a href="#hero">Главная</a>
+          <a href="#features">Возможности</a>
+          <a href="#catalog">Каталог</a>
+          <a href="#platform">Платформа</a>
+          <a href="#gallery">Интерфейс</a>
+          <a href="#contact">Связь</a>
+          <a href="book.html">Каталог книг</a>
+          <a href="BookCategory.html">Категории</a>
         </div>
       </nav>
     </header>
@@ -118,295 +78,167 @@
     <section id="hero" class="hero">
       <div class="container hero__layout">
         <div class="hero__content">
-          <p class="hero__eyebrow lang" data-lang="ru">Структура и логика BooksMed теперь в MedLibrary</p>
-          <p class="hero__eyebrow lang" data-lang="en">BooksMed-inspired structure now inside MedLibrary</p>
-          <p class="hero__eyebrow lang" data-lang="tm">BooksMed logikasy bilen täzelenen MedLibrary</p>
-          <h2 class="hero__title lang" data-lang="ru">Единая медицинская библиотека для обучения и практики</h2>
-          <h2 class="hero__title lang" data-lang="en">A single medical library for learning and practice</h2>
-          <h2 class="hero__title lang" data-lang="tm">Okuw we amaly işler üçin bir platforma</h2>
+          <p class="hero__eyebrow lang" data-lang="ru">Обновленный интерфейс и логика</p>
+          <p class="hero__eyebrow lang" data-lang="en">Refined interface and logic</p>
+          <p class="hero__eyebrow lang" data-lang="tm">Täzelenen interfeýs we logika</p>
+          <h2 class="hero__title lang" data-lang="ru">Каталог медицинских знаний без лишнего</h2>
+          <h2 class="hero__title lang" data-lang="en">A medical catalog without the clutter</h2>
+          <h2 class="hero__title lang" data-lang="tm">Artykmaç maglumatlarsyz lukmançylyk katalogy</h2>
           <p class="hero__text lang" data-lang="ru">
-            Быстрый поиск по 1000+ книгам, готовые категории и офлайн‑режим собраны в одном окне. Архитектура повторяет
-            привычную навигацию BooksMed, но дополнена PWA, авторизацией и мгновенными фильтрами.
+            Фокус только на важном: поиск, категории, офлайн‑режим и установка PWA. Минимум отвлекающих блоков и
+            понятная структура.
           </p>
           <p class="hero__text lang" data-lang="en">
-            Search across 1K+ books with curated categories and offline access. The layout mirrors the familiar BooksMed logic and
-            adds PWA, authentication, and instant filters.
+            The essentials only: search, curated categories, offline mode, and PWA install. A clear, distraction‑free layout
+            inspired by BooksMed.
           </p>
           <p class="hero__text lang" data-lang="tm">
-            1000+ kitap boýunça çalt gözleg, taýýar kategoriýalar we oflaýn elýeterlik — hemmesi bir penjirede. BooksMed
-            ulgamyna meňzeş gurluşa PWA, awtorizasiýa we derrew filtrler goşuldy.
+            Esasy zatlar: gözleg, baý kategoriýalar, oflaýn režimi we PWA gurnama. BooksMed logikasyna meňzeş arassa gurluş.
           </p>
-          <div class="pill-group">
-            <span class="pill">69 направлений</span>
-            <span class="pill">Каталог, категории, поиск</span>
-            <span class="pill">Офлайн и PWA</span>
-          </div>
           <div class="hero__actions">
             <a class="button button--primary" href="book.html">
               <span class="lang" data-lang="ru">Открыть каталог</span>
               <span class="lang" data-lang="en">Open catalog</span>
               <span class="lang" data-lang="tm">Katalogy aç</span>
             </a>
-            <a class="button button--ghost" href="BookCategory.html">
-              <span class="lang" data-lang="ru">Категории BooksMed</span>
-              <span class="lang" data-lang="en">BooksMed-style categories</span>
-              <span class="lang" data-lang="tm">BooksMed kategoriýalary</span>
+            <a class="button button--ghost" href="#platform">
+              <span class="lang" data-lang="ru">Как устроено</span>
+              <span class="lang" data-lang="en">How it works</span>
+              <span class="lang" data-lang="tm">Näme üçin amatly</span>
             </a>
             <button class="button button--text" type="button" data-install-trigger data-install-sticky>
               <span class="lang" data-lang="ru">Установить PWA</span>
               <span class="lang" data-lang="en">Install PWA</span>
               <span class="lang" data-lang="tm">PWA gurnamak</span>
             </button>
-            <a class="button button--text" href="Book.xlsx" download>
-              <span class="lang" data-lang="ru">Каталог в Excel</span>
-              <span class="lang" data-lang="en">Catalog in Excel</span>
-              <span class="lang" data-lang="tm">Excel katalogy</span>
-            </a>
           </div>
-          <div class="hero__metrics">
-            <article class="metric-card">
-              <p class="metric-card__value">1000+</p>
-              <p class="metric-card__label lang" data-lang="ru">Книг и учебников</p>
-              <p class="metric-card__label lang" data-lang="en">Books & textbooks</p>
-              <p class="metric-card__label lang" data-lang="tm">Kitaplar</p>
-            </article>
-            <article class="metric-card">
-              <p class="metric-card__value">69</p>
-              <p class="metric-card__label lang" data-lang="ru">Медицинских направлений</p>
-              <p class="metric-card__label lang" data-lang="en">Medical specialties</p>
-              <p class="metric-card__label lang" data-lang="tm">Lukmançylyk ugurlary</p>
-            </article>
-            <article class="metric-card">
-              <p class="metric-card__value">24/7</p>
-              <p class="metric-card__label lang" data-lang="ru">Онлайн и офлайн доступ</p>
-              <p class="metric-card__label lang" data-lang="en">Online + offline access</p>
-              <p class="metric-card__label lang" data-lang="tm">Onlaýn + oflaýn</p>
-            </article>
+          <div class="stat-grid">
+            <div class="stat-card">
+              <p class="stat-card__value">1000+</p>
+              <p class="stat-card__label">книг в единой таблице</p>
+            </div>
+            <div class="stat-card">
+              <p class="stat-card__value">69</p>
+              <p class="stat-card__label">медицинских направлений</p>
+            </div>
+            <div class="stat-card">
+              <p class="stat-card__value">24/7</p>
+              <p class="stat-card__label">онлайн и офлайн режим</p>
+            </div>
           </div>
-          <ul class="hero-shortcuts" role="list">
-            <li>
-              <a href="book.html">Каталог книг</a>
-              <span>Полная таблица с фильтрами как на booksmed.info</span>
-            </li>
-            <li>
-              <a href="BookCategory.html">Категории</a>
-              <span>69 направлений в знакомом порядке</span>
-            </li>
-            <li>
-              <a href="#contact">Связь</a>
-              <span>Вопросы, интеграции, заявки на книги</span>
-            </li>
-          </ul>
         </div>
         <div class="hero__panel" aria-hidden="true">
-          <div class="hero-card">
-            <div class="hero-card__label">BooksMed logic</div>
-            <h3>Категории, каталог и поиск — в одном экране</h3>
-            <p>Стартовый экран повторяет структуру booksmed.info: слева — навигация, справа — быстрый доступ к разделам.</p>
-            <div class="hero-card__grid">
-              <span class="pill">Каталог</span>
-              <span class="pill">Категории</span>
-              <span class="pill">Поиск</span>
-              <span class="pill">Контакты</span>
+          <div class="preview-card">
+            <div class="preview-card__header">
+              <span class="pill">Быстрый доступ</span>
+              <span class="pill pill--ghost">BooksMed logic</span>
             </div>
-          </div>
-          <div class="hero-card hero-card--image">
-            <img src="1.webp" alt="Каталог MedLibrary" loading="lazy" decoding="async">
-            <div class="hero-card__hint">Открывайте, фильтруйте и скачивайте книги</div>
+            <p class="preview-card__title">Каталог, категории и поиск в одном экране</p>
+            <p class="preview-card__text">Упрощенные акценты и быстрые ссылки на ключевые разделы MedLibrary.</p>
+            <div class="preview-card__actions">
+              <a class="button button--ghost" href="BookCategory.html">Категории</a>
+              <a class="button button--text" href="book.html#table">Фильтры каталога</a>
+            </div>
+            <div class="preview-card__image">
+              <img src="1.webp" alt="Каталог MedLibrary" loading="lazy" decoding="async">
+            </div>
           </div>
         </div>
       </div>
     </section>
 
-    <section id="overview" class="section container library-shell">
+    <section id="features" class="section container">
       <div class="section__head">
-        <p class="eyebrow">Структура как на BooksMed</p>
-        <h2 class="section__title">Главная лента, боковая навигация и короткие блоки помощи</h2>
-        <p class="section__subtitle">
-          Перестроили страницу, чтобы повторить привычное трехколоночное восприятие: слева меню с поиском и кнопками, в центре —
-          поток материалов, справа — поддержка, популярные разделы и архивы.
-        </p>
+        <p class="eyebrow">Возможности</p>
+        <h2 class="section__title">Что осталось, а что стало проще</h2>
+        <p class="section__subtitle">Четкая структура, лаконичные блоки и акцент на сценариях поиска и чтения.</p>
       </div>
-      <div class="library-shell__grid">
-        <aside class="nav-panel">
-          <div class="nav-panel__block">
-            <label class="nav-panel__label" for="site-search">Поиск по библиотеке</label>
-            <div class="nav-panel__search">
-              <input id="site-search" type="search" placeholder="Введите запрос" aria-label="Поиск по библиотеке">
-              <a class="nav-panel__search-link" href="book.html">Открыть расширенный поиск</a>
-            </div>
-          </div>
-          <div class="nav-panel__block">
-            <p class="nav-panel__label">Основные разделы</p>
-            <div class="nav-panel__links">
-              <a href="#catalog">Каталог</a>
-              <a href="BookCategory.html">Категории</a>
-              <a href="#download">Скачать</a>
-              <a href="#contact">Контакты</a>
-              <a href="#gallery">Интерфейс</a>
-            </div>
-          </div>
-          <div class="nav-panel__block nav-panel__tags">
-            <p class="nav-panel__label">Направления</p>
-            <div class="pill">Кардиология</div>
-            <div class="pill">Анатомия</div>
-            <div class="pill">Неврология</div>
-            <div class="pill">Педиатрия</div>
-            <div class="pill">Хирургия</div>
-            <div class="pill">Эндокринология</div>
-          </div>
-          <div class="nav-panel__cta">
-            <p>Нужна помощь с подбором книги?</p>
-            <a class="button button--ghost" href="#contact">Написать разработчику</a>
-          </div>
-        </aside>
-
-        <div class="library-feed" role="feed">
-          <article class="feed-card" role="article">
-            <div class="feed-card__meta">
-              <span class="pill">Новости</span>
-              <span>06.11.2025</span>
-            </div>
-            <h3>Инфаркт миокарда — смертельная угроза и спасение сердца</h3>
-            <p>
-              Инфаркт миокарда — серьезное состояние, требующее мгновенной реакции. Мы собрали проверенные руководства и
-              учебники, чтобы быстрее ориентироваться в диагностике и лечении.
-            </p>
-            <div class="feed-card__actions">
-              <a href="book.html" class="button button--primary">Перейти к каталогу</a>
-              <a href="Book.xlsx" download class="button button--text">Скачать Excel</a>
-            </div>
-          </article>
-
-          <article class="feed-card" role="article">
-            <div class="feed-card__meta">
-              <span class="pill">Статьи</span>
-              <span>22.07.2025</span>
-            </div>
-            <h3>Массаж стоп по китайскому рецепту</h3>
-            <p>
-              Попробуйте альтернативные методики оздоровления: собрали книги и методички по массажу, ЛФК и восстановлению после
-              нагрузок.
-            </p>
-            <div class="feed-card__actions">
-              <a href="BookCategory.html" class="button button--ghost">Открыть категории</a>
-              <a href="book.html#table" class="button button--text">Перейти к поиску</a>
-            </div>
-          </article>
-
-          <article class="feed-card" role="article">
-            <div class="feed-card__meta">
-              <span class="pill">Педиатрия</span>
-              <span>15.02.2025</span>
-            </div>
-            <h3>Ранняя диагностика РАС</h3>
-            <p>
-              Педиатры играют ключевую роль в раннем определении риска расстройств аутистического спектра. Подготовили подборку
-              материалов для скрининга и сопровождения.
-            </p>
-            <div class="feed-card__actions">
-              <a href="book.html" class="button button--ghost">Найти книги</a>
-              <a href="#contact" class="button button--text">Запросить подборку</a>
-            </div>
-          </article>
-
-          <article class="feed-card" role="article">
-            <div class="feed-card__meta">
-              <span class="pill">Диетология</span>
-              <span>01.09.2025</span>
-            </div>
-            <h3>Профилактика метаболического синдрома у детей</h3>
-            <p>
-              Обновили разделы с международными рекомендациями по питанию и физической активности. Фильтры позволяют быстро
-              отобрать нужные руководства.
-            </p>
-            <div class="feed-card__actions">
-              <a href="book.html" class="button button--primary">Перейти к фильтрам</a>
-              <a href="BookCategory.html" class="button button--text">Открыть направление</a>
-            </div>
-          </article>
-        </div>
-
-        <aside class="library-aside">
-          <div class="aside-card aside-card--accent">
-            <p class="aside-card__title">Поддержите библиотеку</p>
-            <p>Помогите развивать MedLibrary и добавлять новые книги.</p>
-            <div class="aside-card__donate">
-              <p><strong>USDT (TRC20)</strong> — TXpBhNvPWNvHNv44R8968hmCLXui32pLzi</p>
-              <p><strong>USDC (ERC20)</strong> — 0x1a814e58f9d97591767a74904ff1e1dc5261e5fc</p>
-            </div>
-          </div>
-
-          <div class="aside-card">
-            <p class="aside-card__title">Популярное</p>
-            <ul class="aside-list">
-              <li><a href="book.html">Каталог книг с быстрым поиском</a></li>
-              <li><a href="BookCategory.html">69 медицинских направлений</a></li>
-              <li><a href="db-catalog.html">Каталог из SQLite</a></li>
-              <li><a href="#download">PWA и офлайн-доступ</a></li>
-            </ul>
-          </div>
-
-          <div class="aside-card">
-            <p class="aside-card__title">Архив обновлений</p>
-            <div class="archive-grid">
-              <a href="#catalog">Ноябрь 2025</a>
-              <a href="#catalog">Октябрь 2025</a>
-              <a href="#catalog">Сентябрь 2025</a>
-              <a href="#catalog">Август 2025</a>
-              <a href="#catalog">Июль 2025</a>
-              <a href="#catalog">Июнь 2025</a>
-            </div>
-          </div>
-        </aside>
+      <div class="feature-grid">
+        <article class="feature-card">
+          <div class="feature-icon" aria-hidden="true">📚</div>
+          <h3>Единый каталог</h3>
+          <p>Таблица с 1000+ книгами, быстрыми фильтрами и карточками — без лишних панелей и новостных блоков.</p>
+        </article>
+        <article class="feature-card">
+          <div class="feature-icon" aria-hidden="true">🧭</div>
+          <h3>Категории BooksMed</h3>
+          <p>69 направлений в привычной логике. Один клик — и сразу к нужной области знаний.</p>
+        </article>
+        <article class="feature-card">
+          <div class="feature-icon" aria-hidden="true">🔍</div>
+          <h3>Поиск без шумов</h3>
+          <p>Глобальный поиск по всем колонкам с нормализацией текста. Минимум отвлекающих элементов.</p>
+        </article>
+        <article class="feature-card">
+          <div class="feature-icon" aria-hidden="true">⚡</div>
+          <h3>Быстрый старт</h3>
+          <p>Готовые кнопки: каталог, категории, Excel/JSON и PWA — все под рукой на первом экране.</p>
+        </article>
       </div>
     </section>
 
-    <section id="catalog" class="section info-panels container">
-      <div class="info-panels__grid">
-        <article class="info-card">
-          <div class="feature-icon" aria-hidden="true">📚</div>
-          <h3>Каталог</h3>
-          <p>Мгновенное открытие списка книг с сортировками, карточками и экспортом в Excel/JSON.</p>
-          <div class="cta-inline">
-            <a class="button button--primary" href="book.html">Каталог книг</a>
-            <a class="button button--ghost" href="Book.xlsx" download>Скачать Excel</a>
-          </div>
+    <section id="catalog" class="section section--split container">
+      <div>
+        <div class="section__head">
+          <p class="eyebrow">Каталог</p>
+          <h2 class="section__title">Таблица, карточки и экспорт</h2>
+          <p class="section__subtitle">Используйте таблицу как на BooksMed: сортировки, фильтры по колонкам, экспорт в Excel или JSON.</p>
+        </div>
+        <ul class="checklist">
+          <li>Поиск по названию, авторам, ISBN, УДК, ББК</li>
+          <li>Карточки найденных книг без перегруза информации</li>
+          <li>Экспорт в Excel/JSON и офлайн-доступ</li>
+        </ul>
+        <div class="cta-inline">
+          <a class="button button--primary" href="book.html">Каталог книг</a>
+          <a class="button button--ghost" href="Book.xlsx" download>Excel</a>
+          <a class="button button--text" href="data/books.json" download>JSON</a>
+        </div>
+      </div>
+      <div class="accent-card">
+        <p class="accent-card__eyebrow">Подборка за секунды</p>
+        <h3 class="accent-card__title">Готовые маршруты</h3>
+        <div class="accent-card__tags">
+          <span class="pill">Кардиология</span>
+          <span class="pill">Педиатрия</span>
+          <span class="pill">Хирургия</span>
+          <span class="pill">Анатомия</span>
+          <span class="pill">Диагностика</span>
+        </div>
+        <p class="accent-card__text">Категории и фильтры открываются в соседних вкладках, чтобы быстрее найти нужный материал.</p>
+      </div>
+    </section>
+
+    <section id="platform" class="section container">
+      <div class="section__head">
+        <p class="eyebrow">Платформа</p>
+        <h2 class="section__title">Современная логика без лишнего шума</h2>
+        <p class="section__subtitle">Легкий интерфейс, PWA, офлайн-режим и плавные сценарии авторизации.</p>
+      </div>
+      <div class="platform__grid">
+        <article class="platform__card">
+          <h3>PWA и офлайн</h3>
+          <p>Сервис-воркер кэширует каталог, поэтому поиск и чтение продолжаются даже без сети.</p>
+          <button class="button button--text" type="button" data-install-trigger data-install-sticky>Установить</button>
         </article>
-        <article class="info-card">
-          <div class="feature-icon" aria-hidden="true">🧭</div>
-          <h3>Категории</h3>
-          <p>69 тематических направлений как на BooksMed: от анатомии до хирургии, с быстрым фильтром.</p>
-          <div class="cta-inline">
-            <a class="button button--ghost" href="BookCategory.html">Категории</a>
-            <a class="button button--text" href="book.html#table">Применить фильтры</a>
-          </div>
+        <article class="platform__card">
+          <h3>Авторизация</h3>
+          <p>Регистрация, вход, Google Identity и понятные статусы. Нет лишних форм — только essentials.</p>
+          <button class="button button--ghost auth-open-button" type="button">Открыть окно входа</button>
         </article>
-        <article class="info-card">
-          <div class="feature-icon" aria-hidden="true">🔍</div>
-          <h3>Поиск</h3>
-          <p>Глобальный поиск по всем колонкам каталога с учетом диакритики и подсказками по категориям.</p>
-          <div class="cta-inline">
-            <a class="button button--ghost" href="book.html#table">Перейти к таблице</a>
-            <a class="button button--text" href="db-catalog.html">SQLite каталог</a>
-          </div>
-        </article>
-        <article class="info-card">
-          <div class="feature-icon" aria-hidden="true">📞</div>
-          <h3>Контакты</h3>
-          <p>Прямая связь с разработчиком: задавайте вопросы, заказывайте добавление книг и интеграции.</p>
-          <div class="cta-inline">
-            <a class="button button--ghost" href="#contact">Написать</a>
-            <a class="button button--text" href="#download">Установить PWA</a>
-          </div>
+        <article class="platform__card">
+          <h3>Структура BooksMed</h3>
+          <p>Навигация, категории и фильтры повторяют логику BooksMed, но с более чистым визуалом.</p>
+          <a class="button button--text" href="BookCategory.html">Перейти к категориям</a>
         </article>
       </div>
     </section>
 
     <section id="gallery" class="gallery-slider section container">
       <div class="section__head">
-        <p class="eyebrow">Gallery</p>
-        <h2>Интерфейс MedLibrary</h2>
+        <p class="eyebrow">Интерфейс</p>
+        <h2>Как выглядит обновление</h2>
+        <p class="section__subtitle">Светлые карточки, четкие акценты и быстрые кнопки.</p>
       </div>
       <div class="gallery-slider__viewport">
         <div class="slide"><img src="1.webp" alt="Каталог MedLibrary" loading="lazy" decoding="async"></div>
@@ -420,38 +252,17 @@
       <button class="gallery-slider__control next" type="button" aria-label="Следующее изображение">&#10095;</button>
     </section>
 
-    <section id="download" class="download section container">
-      <div class="section__head">
-        <p class="eyebrow">Install</p>
-        <h2>Скачайте MedLibrary или работайте офлайн</h2>
-        <p>Установите PWA, чтобы повторить опыт BooksMed в формате приложения, или скачайте каталог для локальной работы.</p>
-      </div>
-      <div class="download__actions">
-        <button class="button button--primary" type="button" data-install-trigger data-install-sticky>Установить приложение</button>
-        <a class="button button--ghost" href="data/books.json" download>
-          <span class="lang" data-lang="ru">Скачать JSON каталог</span>
-          <span class="lang" data-lang="en">Download JSON catalog</span>
-          <span class="lang" data-lang="tm">JSON katalogy</span>
-        </a>
-      </div>
-      <ul class="checklist checklist--inline">
-        <li>Android / Windows / macOS</li>
-        <li>Сервис‑воркер с динамическим кэшем</li>
-        <li>Глобальные и локальные ресурсы офлайн</li>
-      </ul>
-    </section>
-
     <section id="contact" class="contact section container">
       <div class="section__head">
-        <p class="eyebrow lang" data-lang="ru">Всегда на связи</p>
-        <p class="eyebrow lang" data-lang="en">Stay in touch</p>
+        <p class="eyebrow lang" data-lang="ru">Связь</p>
+        <p class="eyebrow lang" data-lang="en">Contact</p>
         <p class="eyebrow lang" data-lang="tm">Habarlaşyň</p>
         <h2 class="section__title lang" data-lang="ru">Напишите разработчику</h2>
         <h2 class="section__title lang" data-lang="en">Get in touch</h2>
         <h2 class="section__title lang" data-lang="tm">Habarlaşyň</h2>
-        <p class="section__subtitle lang" data-lang="ru">Расскажите, что еще перенести из BooksMed или какие книги добавить.</p>
-        <p class="section__subtitle lang" data-lang="en">Tell us what else to bring from BooksMed or which books to add.</p>
-        <p class="section__subtitle lang" data-lang="tm">BooksMed-dan başga nämeleri goşmak ýa-da haýsy kitaplary goşmak barada ýazyň.</p>
+        <p class="section__subtitle lang" data-lang="ru">Предложите книги, интеграции или улучшения интерфейса.</p>
+        <p class="section__subtitle lang" data-lang="en">Share books to add, integrations, or UX ideas.</p>
+        <p class="section__subtitle lang" data-lang="tm">Goşmaly kitaplary, integrasiýalary ýa-da UX teklipleriňizi iberiň.</p>
       </div>
       <form class="contact__form" onsubmit="sendMail(); return false;">
         <label class="form-group">
@@ -491,7 +302,7 @@
     <div class="container site-footer__content">
       <div>
         <strong>© 2025 MedLibrary</strong>
-        <p>Медицинская электронная библиотека. Все права защищены.</p>
+        <p>Медицинская электронная библиотека.</p>
       </div>
       <div class="site-footer__links">
         <a href="index.html">Главная</a>

--- a/styles.css
+++ b/styles.css
@@ -1,10 +1,12 @@
 :root {
   color-scheme: light;
-  --page-bg: #f5f7fb;
+  --page-bg: radial-gradient(circle at 10% 20%, rgba(26, 108, 255, 0.08), transparent 32%),
+    radial-gradient(circle at 80% 0%, rgba(11, 146, 222, 0.06), transparent 28%),
+    #f6f7fb;
   --surface: #ffffff;
   --surface-soft: #eef2f7;
-  --text: #0f172a;
-  --muted: #4b5563;
+  --text: #0b1224;
+  --muted: #475569;
   --primary: #1a6cff;
   --primary-2: #5ea3ff;
   --border: #e2e8f0;
@@ -19,9 +21,7 @@
 body {
   margin: 0;
   min-height: 100vh;
-  background: radial-gradient(circle at 20% 20%, rgba(26, 108, 255, 0.08), transparent 32%),
-    radial-gradient(circle at 80% 0%, rgba(11, 146, 222, 0.08), transparent 30%),
-    var(--page-bg);
+  background: var(--page-bg);
   color: var(--text);
   line-height: 1.6;
 }
@@ -58,7 +58,7 @@ main {
   top: 0;
   z-index: 10;
   backdrop-filter: blur(12px);
-  background: rgba(255, 255, 255, 0.92);
+  background: rgba(255, 255, 255, 0.96);
   border-bottom: 1px solid var(--border);
   box-shadow: 0 10px 30px rgba(15, 23, 42, 0.04);
 }
@@ -195,15 +195,40 @@ main {
 .hero__content {
   display: grid;
   gap: 0.85rem;
-  padding: clamp(1.5rem, 3vw, 2rem);
-  background: var(--surface);
+  padding: clamp(1.6rem, 3vw, 2.4rem);
+  background: linear-gradient(135deg, #ffffff, #f3f6ff);
   border: 1px solid var(--border);
-  border-radius: 18px;
-  box-shadow: var(--shadow);
+  border-radius: 22px;
+  box-shadow: 0 25px 60px rgba(15, 23, 42, 0.08);
 }
 
 .hero__title { margin: 0; font-size: clamp(2rem, 4vw, 2.8rem); }
 .hero__text { margin: 0; color: var(--muted); }
+
+.stat-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 0.75rem;
+}
+
+.stat-card {
+  padding: 0.9rem 1rem;
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  background: #fff;
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.06);
+}
+
+.stat-card__value {
+  margin: 0;
+  font-size: 1.6rem;
+  font-weight: 800;
+}
+
+.stat-card__label {
+  margin: 0.15rem 0 0;
+  color: var(--muted);
+}
 
 .pill-group {
   display: flex;
@@ -221,6 +246,12 @@ main {
   border: 1px solid var(--border);
   font-weight: 600;
   color: var(--muted);
+}
+
+.pill--ghost {
+  background: transparent;
+  color: #cbd5e1;
+  border-color: rgba(255, 255, 255, 0.25);
 }
 
 .hero__actions {
@@ -278,37 +309,40 @@ main {
   gap: 1rem;
 }
 
-.hero-card {
-  background: var(--surface);
-  border: 1px solid var(--border);
-  border-radius: 18px;
-  padding: 1.25rem;
-  box-shadow: var(--shadow);
+.preview-card {
+  background: #0b1224;
+  color: #e2e8f0;
+  border-radius: 22px;
+  padding: 1.4rem;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 24px 50px rgba(0, 0, 0, 0.2);
+  display: grid;
+  gap: 0.75rem;
 }
 
-.hero-card__label {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  padding: 0.35rem 0.65rem;
-  border-radius: 999px;
-  background: #eaf1ff;
-  color: var(--primary);
-  font-weight: 700;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  font-size: 0.75rem;
-}
-
-.hero-card__grid {
+.preview-card__header {
   display: flex;
   flex-wrap: wrap;
   gap: 0.5rem;
-  margin-top: 0.5rem;
+  align-items: center;
 }
 
-.hero-card--image img { border-radius: 12px; }
-.hero-card__hint { margin-top: 0.5rem; color: var(--muted); }
+.preview-card__title {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.preview-card__text { margin: 0; color: #cbd5e1; }
+
+.preview-card__actions { display: flex; gap: 0.5rem; flex-wrap: wrap; }
+
+.preview-card__image {
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+}
+.preview-card__image img { width: 100%; display: block; }
 
 .section {
   background: var(--surface);
@@ -377,6 +411,8 @@ main {
 
 .accent-card__eyebrow { text-transform: uppercase; letter-spacing: 0.15em; color: var(--primary); font-weight: 700; }
 .accent-card__tags { display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.5rem; }
+.accent-card__title { margin: 0.35rem 0 0.25rem; }
+.accent-card__text { margin: 0.35rem 0 0; color: var(--muted); }
 
 .platform__grid {
   display: grid;


### PR DESCRIPTION
## Summary
- rebuild the landing page with concise hero, feature, catalog, platform, gallery, and contact sections
- remove noisy sidebar/news blocks and highlight key navigation/actions that mirror BooksMed logic
- refresh styling with updated palette, stat cards, and preview panel for the streamlined layout

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69229aa0d17083298eab870a6fce7ec0)