### PR TITLE
Refine landing page focus and design

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,14 +25,14 @@
     <header class="site-header">
       <div class="container site-header__bar">
         <div class="site-header__brand">
-          <p class="eyebrow lang" data-lang="ru">цифровая медицинская библиотека</p>
-          <p class="eyebrow lang" data-lang="en">digital medical library</p>
-          <p class="eyebrow lang" data-lang="tm">sanly lukmançylyk kitaphanasy</p>
+          <p class="eyebrow lang" data-lang="ru">актуальная медицинская библиотека</p>
+          <p class="eyebrow lang" data-lang="en">focused medical library</p>
+          <p class="eyebrow lang" data-lang="tm">üstünlikli lukmançylyk kitaphanasy</p>
           <h1 class="site-header__title lang" data-lang="ru">MedLibrary</h1>
           <h1 class="site-header__title lang" data-lang="en">MedLibrary</h1>
           <h1 class="site-header__title lang" data-lang="tm">MedLibrary</h1>
           <p class="site-header__lead">
-            Единый каталог, логика BooksMed и PWA-доступ в одном аккуратном интерфейсе.
+            Чистая структура, меньше отвлекающих блоков и быстрые сценарии поиска по логике BooksMed.
           </p>
         </div>
         <div class="site-header__actions">
@@ -78,22 +78,23 @@
     <section id="hero" class="hero">
       <div class="container hero__layout">
         <div class="hero__content">
-          <p class="hero__eyebrow lang" data-lang="ru">Обновленный интерфейс и логика</p>
-          <p class="hero__eyebrow lang" data-lang="en">Refined interface and logic</p>
-          <p class="hero__eyebrow lang" data-lang="tm">Täzelenen interfeýs we logika</p>
-          <h2 class="hero__title lang" data-lang="ru">Каталог медицинских знаний без лишнего</h2>
-          <h2 class="hero__title lang" data-lang="en">A medical catalog without the clutter</h2>
-          <h2 class="hero__title lang" data-lang="tm">Artykmaç maglumatlarsyz lukmançylyk katalogy</h2>
+          <p class="hero__eyebrow lang" data-lang="ru">Современный сценарий</p>
+          <p class="hero__eyebrow lang" data-lang="en">Modern experience</p>
+          <p class="hero__eyebrow lang" data-lang="tm">Täzeçillik tejribesi</p>
+          <h2 class="hero__title lang" data-lang="ru">Каталог медицинских знаний без шума</h2>
+          <h2 class="hero__title lang" data-lang="en">A clean medical catalog</h2>
+          <h2 class="hero__title lang" data-lang="tm">Arassa lukmançylyk katalogy</h2>
           <p class="hero__text lang" data-lang="ru">
-            Фокус только на важном: поиск, категории, офлайн‑режим и установка PWA. Минимум отвлекающих блоков и
-            понятная структура.
+            Убрали лишние блоки, оставили базовые сценарии: поиск, категории, офлайн‑режим и установка PWA. Акценты и
+            кнопки ведут к основным действиям.
           </p>
           <p class="hero__text lang" data-lang="en">
-            The essentials only: search, curated categories, offline mode, and PWA install. A clear, distraction‑free layout
-            inspired by BooksMed.
+            We trimmed the noise and kept the essentials: search, curated categories, offline mode, and a clear PWA install
+            flow inspired by BooksMed.
           </p>
           <p class="hero__text lang" data-lang="tm">
-            Esasy zatlar: gözleg, baý kategoriýalar, oflaýn režimi we PWA gurnama. BooksMed logikasyna meňzeş arassa gurluş.
+            Goýbolsun edildi artyk bloklar: gözleg, baý kategoriýalar, oflaýn režimi we düşnükli PWA gurnama.
+            BooksMed logikasyna meňzeş arassa gurluş.
           </p>
           <div class="hero__actions">
             <a class="button button--primary" href="book.html">
@@ -112,19 +113,10 @@
               <span class="lang" data-lang="tm">PWA gurnamak</span>
             </button>
           </div>
-          <div class="stat-grid">
-            <div class="stat-card">
-              <p class="stat-card__value">1000+</p>
-              <p class="stat-card__label">книг в единой таблице</p>
-            </div>
-            <div class="stat-card">
-              <p class="stat-card__value">69</p>
-              <p class="stat-card__label">медицинских направлений</p>
-            </div>
-            <div class="stat-card">
-              <p class="stat-card__value">24/7</p>
-              <p class="stat-card__label">онлайн и офлайн режим</p>
-            </div>
+          <div class="hero__meta">
+            <span class="pill">1000+ книг в таблице</span>
+            <span class="pill">69 направлений</span>
+            <span class="pill">Онлайн и офлайн доступ</span>
           </div>
         </div>
         <div class="hero__panel" aria-hidden="true">
@@ -134,7 +126,7 @@
               <span class="pill pill--ghost">BooksMed logic</span>
             </div>
             <p class="preview-card__title">Каталог, категории и поиск в одном экране</p>
-            <p class="preview-card__text">Упрощенные акценты и быстрые ссылки на ключевые разделы MedLibrary.</p>
+            <p class="preview-card__text">Чистые карточки, быстрый доступ к таблице и категориям — без лишних панелей.</p>
             <div class="preview-card__actions">
               <a class="button button--ghost" href="BookCategory.html">Категории</a>
               <a class="button button--text" href="book.html#table">Фильтры каталога</a>
@@ -147,17 +139,46 @@
       </div>
     </section>
 
+    <section id="audit" class="section section--split container info-hygiene">
+      <div>
+        <div class="section__head">
+          <p class="eyebrow">Информационная гигиена</p>
+          <h2 class="section__title">Мы оставили только нужное</h2>
+          <p class="section__subtitle">
+            Фокус на поиске, чтении и установке PWA. Новости, баннеры и второстепенные блоки скрыты, чтобы не мешать работе.
+          </p>
+        </div>
+        <ul class="checklist">
+          <li>Минимальная навигация: каталог, категории, авторизация</li>
+          <li>Четкие CTA — открыть каталог, скачать JSON/Excel, установить PWA</li>
+          <li>Подсказки по горячим клавишам только там, где они полезны</li>
+          <li>Плотные карточки с ключевыми метаданными книги</li>
+        </ul>
+      </div>
+      <div class="info-hygiene__panel">
+        <p class="info-hygiene__eyebrow">Новые опорные точки</p>
+        <h3 class="info-hygiene__title">Быстрые переходы</h3>
+        <div class="pill-row">
+          <a class="pill pill--ghost" href="book.html">Таблица каталога</a>
+          <a class="pill pill--ghost" href="BookCategory.html">69 направлений</a>
+          <a class="pill pill--ghost" href="Book.xlsx" download>Экспорт Excel</a>
+          <a class="pill pill--ghost" href="data/books.json" download>JSON для интеграций</a>
+        </div>
+        <p class="info-hygiene__note">Весь лишний контент убран в пользу быстрых сценариев поиска и скачивания.</p>
+      </div>
+    </section>
+
     <section id="features" class="section container">
       <div class="section__head">
         <p class="eyebrow">Возможности</p>
-        <h2 class="section__title">Что осталось, а что стало проще</h2>
-        <p class="section__subtitle">Четкая структура, лаконичные блоки и акцент на сценариях поиска и чтения.</p>
+        <h2 class="section__title">Главные сценарии без лишнего</h2>
+        <p class="section__subtitle">Только то, что помогает найти, открыть или сохранить книгу.</p>
       </div>
       <div class="feature-grid">
         <article class="feature-card">
           <div class="feature-icon" aria-hidden="true">📚</div>
           <h3>Единый каталог</h3>
-          <p>Таблица с 1000+ книгами, быстрыми фильтрами и карточками — без лишних панелей и новостных блоков.</p>
+          <p>Таблица с 1000+ книгами, быстрыми фильтрами и карточками — без новостных блоков и отвлекающих панелей.</p>
         </article>
         <article class="feature-card">
           <div class="feature-icon" aria-hidden="true">🧭</div>
@@ -167,12 +188,12 @@
         <article class="feature-card">
           <div class="feature-icon" aria-hidden="true">🔍</div>
           <h3>Поиск без шумов</h3>
-          <p>Глобальный поиск по всем колонкам с нормализацией текста. Минимум отвлекающих элементов.</p>
+          <p>Глобальный поиск по всем колонкам с нормализацией текста. Минимум отвлекающих элементов и вспомогательных окон.</p>
         </article>
         <article class="feature-card">
           <div class="feature-icon" aria-hidden="true">⚡</div>
           <h3>Быстрый старт</h3>
-          <p>Готовые кнопки: каталог, категории, Excel/JSON и PWA — все под рукой на первом экране.</p>
+          <p>Готовые кнопки: каталог, категории, Excel/JSON и PWA — никакой лишней навигации.</p>
         </article>
       </div>
     </section>
@@ -182,7 +203,7 @@
         <div class="section__head">
           <p class="eyebrow">Каталог</p>
           <h2 class="section__title">Таблица, карточки и экспорт</h2>
-          <p class="section__subtitle">Используйте таблицу как на BooksMed: сортировки, фильтры по колонкам, экспорт в Excel или JSON.</p>
+          <p class="section__subtitle">Бережно обновленная структура: сортировки, фильтры по колонкам и чистые карточки.</p>
         </div>
         <ul class="checklist">
           <li>Поиск по названию, авторам, ISBN, УДК, ББК</li>

--- a/styles.css
+++ b/styles.css
@@ -249,15 +249,22 @@ main {
 }
 
 .pill--ghost {
-  background: transparent;
-  color: #cbd5e1;
-  border-color: rgba(255, 255, 255, 0.25);
+  background: #0b12240a;
+  color: var(--text);
+  border-color: rgba(26, 108, 255, 0.25);
 }
 
 .hero__actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.65rem;
+}
+
+.hero__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-top: 0.5rem;
 }
 
 .hero__metrics {
@@ -379,6 +386,45 @@ main {
   gap: 1.25rem;
   align-items: start;
 }
+
+.pill-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.info-hygiene {
+  position: relative;
+  overflow: hidden;
+}
+
+.info-hygiene::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle at 80% 20%, rgba(26, 108, 255, 0.08), transparent 35%);
+  pointer-events: none;
+}
+
+.info-hygiene__panel {
+  position: relative;
+  padding: 1.25rem;
+  border-radius: 16px;
+  background: linear-gradient(150deg, #0b1224, #132743);
+  color: #e8eeff;
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 18px 50px rgba(11, 18, 36, 0.25);
+}
+
+.info-hygiene__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: #8fb7ff;
+  margin: 0 0 0.25rem;
+}
+
+.info-hygiene__title { margin: 0 0 0.5rem; }
+.info-hygiene__note { margin: 0.75rem 0 0; color: #cdd9ff; }
 
 .checklist {
   list-style: none;


### PR DESCRIPTION
## Summary
- Streamlined landing hero copy to emphasize core catalog and PWA flows and removed noisy messaging.
- Added an information hygiene section with quick links to the catalog, categories, and exports.
- Refreshed styling for pills and supporting panels to highlight key actions with a modern look.

## Testing
- Not run (not requested).


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69229c6dc29c8329b2da935cf5ec6c49)