### PR TITLE
Unify layout and enable Turkmen-first localization

### DIFF
--- a/BookCategory.html
+++ b/BookCategory.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ru" data-lang="ru">
+<html lang="tm" data-lang="tm">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -24,8 +24,8 @@
     </div>
     <div class="site-header__actions">
       <select id="language-select" aria-label="Сменить язык">
-        <option value="tm">Türkmençe</option>
-        <option value="ru" selected>Русский</option>
+        <option value="tm" selected>Türkmençe</option>
+        <option value="ru">Русский</option>
         <option value="en">English</option>
       </select>
       <button id="install-button" class="button button--ghost" type="button" hidden data-install-trigger>

--- a/book.html
+++ b/book.html
@@ -1,414 +1,44 @@
 <!DOCTYPE html>
-<html lang="ru" data-lang="ru">
+<html lang="tm" data-lang="tm">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="theme-color" content="#0d47a1">
   <title>Медицинская электронная библиотека — книги</title>
-  <link rel="manifest" href="/MedLibrary/manifest.webmanifest">
+  <link rel="manifest" href="manifest.webmanifest">
   <link rel="preconnect" href="https://fonts.googleapis.com">
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-  <style>
-    :root {
-      color-scheme: light;
-      --bg: #f5f6fb;
-      --card-bg: #ffffff;
-      --primary: #0b6efd;
-      --primary-dark: #084298;
-      --text: #1f2a37;
-      --muted: #5f6b7c;
-      --border: #d9e0ec;
-      --shadow: 0 12px 32px rgba(15, 23, 42, 0.08);
-      --chip-bg: #e7f1ff;
-      --chip-text: #1c4ed8;
-      font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
-    }
-
-    * {
-      box-sizing: border-box;
-    }
-
-    body {
-      margin: 0;
-      min-height: 100vh;
-      background: var(--bg);
-      color: var(--text);
-      line-height: 1.6;
-    }
-
-    a {
-      color: var(--primary);
-      text-decoration: none;
-    }
-
-    .site-header {
-      background: var(--card-bg);
-      padding: 1.5rem clamp(1rem, 4vw, 4rem);
-      display: flex;
-      flex-wrap: wrap;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-      box-shadow: 0 1px 0 rgba(15, 23, 42, 0.08);
-      position: sticky;
-      top: 0;
-      z-index: 10;
-    }
-
-    .logo-area {
-      display: flex;
-      flex-direction: column;
-      gap: 0.2rem;
-    }
-
-    .logo-area__eyebrow {
-      font-size: 0.9rem;
-      letter-spacing: 0.08em;
-      text-transform: uppercase;
-      color: var(--muted);
-    }
-
-    .logo-area__title {
-      font-size: clamp(1.5rem, 2vw, 2rem);
-      margin: 0;
-    }
-
-    .language-switcher {
-      display: flex;
-      align-items: center;
-      gap: 0.5rem;
-      font-weight: 500;
-    }
-
-    select {
-      border-radius: 999px;
-      border: 1px solid var(--border);
-      padding: 0.4rem 1.2rem;
-      font-size: 1rem;
-      font-family: inherit;
-      background: #fff;
-      color: var(--text);
-      transition: border-color 0.2s ease, box-shadow 0.2s ease;
-    }
-
-    select:focus-visible, input:focus-visible {
-      outline: none;
-      border-color: var(--primary);
-      box-shadow: 0 0 0 3px rgba(11, 110, 253, 0.15);
-    }
-
-    nav {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 1rem;
-      padding: 0.75rem clamp(1rem, 4vw, 4rem);
-      background: transparent;
-    }
-
-    nav a {
-      font-weight: 500;
-      color: var(--muted);
-      padding: 0.25rem 0.5rem;
-      border-radius: 999px;
-      transition: color 0.2s ease, background 0.2s ease;
-    }
-
-    nav a:hover,
-    nav a:focus-visible {
-      color: var(--primary);
-      background: rgba(11, 110, 253, 0.08);
-    }
-
-    main {
-      padding: 2rem clamp(1rem, 4vw, 4rem) 4rem;
-      display: flex;
-      flex-direction: column;
-      gap: 2rem;
-    }
-
-    .filter-panel {
-      background: var(--card-bg);
-      border-radius: 24px;
-      padding: clamp(1.5rem, 3vw, 2.5rem);
-      box-shadow: var(--shadow);
-    }
-
-    .filter-panel__head {
-      margin-bottom: 1.5rem;
-    }
-
-    .filter-panel__title {
-      margin: 0 0 0.3rem;
-      font-size: clamp(1.5rem, 2vw, 2rem);
-    }
-
-    .filter-panel__subtitle {
-      margin: 0;
-      color: var(--muted);
-    }
-
-    .filter-form {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
-      gap: 1rem;
-      align-items: end;
-    }
-
-    .filter-field {
-      display: flex;
-      flex-direction: column;
-      gap: 0.35rem;
-      font-weight: 500;
-      color: var(--muted);
-    }
-
-    .filter-field input {
-      border-radius: 14px;
-      border: 1px solid var(--border);
-      padding: 0.85rem 1rem;
-      font-size: 1rem;
-      font-family: inherit;
-      transition: border-color 0.2s ease, box-shadow 0.2s ease, transform 0.2s ease;
-      background: #fdfdff;
-    }
-
-    .filter-field input:hover {
-      transform: translateY(-1px);
-      border-color: var(--primary);
-    }
-
-    .filter-actions {
-      display: flex;
-      gap: 0.75rem;
-      flex-wrap: wrap;
-      margin-top: 0.5rem;
-    }
-
-    .button {
-      border: none;
-      border-radius: 14px;
-      padding: 0.85rem 1.5rem;
-      font-size: 1rem;
-      font-weight: 600;
-      font-family: inherit;
-      cursor: pointer;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-    }
-
-    .button--primary {
-      background: var(--primary);
-      color: #fff;
-      box-shadow: 0 12px 20px rgba(11, 110, 253, 0.25);
-    }
-
-    .button--primary:hover {
-      transform: translateY(-2px);
-      background: var(--primary-dark);
-    }
-
-    .button--ghost {
-      background: rgba(15, 23, 42, 0.06);
-      color: var(--text);
-    }
-
-    .status-bar {
-      display: flex;
-      justify-content: space-between;
-      align-items: center;
-      gap: 1rem;
-      flex-wrap: wrap;
-    }
-
-    .status-pill {
-      background: var(--card-bg);
-      border-radius: 999px;
-      padding: 0.35rem 0.95rem;
-      color: var(--muted);
-      font-weight: 500;
-      box-shadow: 0 8px 18px rgba(15, 23, 42, 0.08);
-    }
-
-    .book-grid {
-      display: grid;
-      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-      gap: 1.5rem;
-    }
-
-    .book-card {
-      background: var(--card-bg);
-      border-radius: 24px;
-      padding: 1.5rem;
-      box-shadow: var(--shadow);
-      display: flex;
-      flex-direction: column;
-      gap: 1rem;
-      transition: transform 0.25s ease, box-shadow 0.25s ease;
-      min-height: 280px;
-    }
-
-    .book-card__media {
-      width: 100%;
-      aspect-ratio: 3 / 4;
-      border-radius: 18px;
-      overflow: hidden;
-      position: relative;
-      background: linear-gradient(135deg, rgba(11, 110, 253, 0.15), rgba(15, 23, 42, 0.15));
-      box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.04);
-    }
-
-    .book-card__media img {
-      width: 100%;
-      height: 100%;
-      object-fit: cover;
-      display: block;
-    }
-
-    .book-card:hover {
-      transform: translateY(-6px) scale(1.01);
-      box-shadow: 0 20px 35px rgba(15, 23, 42, 0.15);
-    }
-
-    .book-card__top {
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
-      gap: 0.5rem;
-      flex-wrap: wrap;
-    }
-
-    .book-card__chip {
-      background: var(--chip-bg);
-      color: var(--chip-text);
-      padding: 0.2rem 0.85rem;
-      border-radius: 999px;
-      font-size: 0.85rem;
-      font-weight: 600;
-    }
-
-    .book-card__title {
-      margin: 0;
-      font-size: 1.15rem;
-      line-height: 1.4;
-    }
-
-    .book-card__author {
-      margin: 0;
-      color: var(--muted);
-      font-size: 0.95rem;
-    }
-
-    .book-card__details {
-      display: grid;
-      grid-template-columns: repeat(2, minmax(0, 1fr));
-      gap: 0.65rem 1rem;
-      font-size: 0.9rem;
-    }
-
-    .book-card__label {
-      color: var(--muted);
-      font-size: 0.8rem;
-      text-transform: uppercase;
-      letter-spacing: 0.08em;
-      display: block;
-    }
-
-    .book-card__actions {
-      margin-top: auto;
-      display: flex;
-      gap: 0.75rem;
-      flex-wrap: wrap;
-    }
-
-    .book-card__link {
-      display: inline-flex;
-      align-items: center;
-      justify-content: center;
-      gap: 0.4rem;
-      border-radius: 14px;
-      padding: 0.7rem 1.2rem;
-      font-weight: 600;
-      background: var(--primary);
-      color: #fff;
-      transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
-      flex: 1;
-      min-width: 160px;
-    }
-
-    .book-card__link:hover {
-      transform: translateY(-2px);
-      background: var(--primary-dark);
-      box-shadow: 0 15px 20px rgba(11, 110, 253, 0.2);
-    }
-
-    .book-card__link[aria-disabled="true"] {
-      cursor: not-allowed;
-      background: rgba(15, 23, 42, 0.12);
-      box-shadow: none;
-    }
-
-    .empty-state {
-      grid-column: 1 / -1;
-      background: rgba(11, 110, 253, 0.08);
-      color: var(--primary-dark);
-      padding: 2rem;
-      border-radius: 24px;
-      text-align: center;
-      font-weight: 600;
-    }
-
-    footer {
-      background: #0f172a;
-      color: rgba(255, 255, 255, 0.8);
-      padding: 2.5rem clamp(1rem, 4vw, 4rem);
-      margin-top: 3rem;
-    }
-
-    .footer-content {
-      display: flex;
-      flex-wrap: wrap;
-      gap: 2rem;
-      justify-content: space-between;
-    }
-
-    .footer-content a {
-      color: #fff;
-      font-weight: 600;
-    }
-
-    @media (max-width: 720px) {
-      .book-card__details {
-        grid-template-columns: 1fr;
-      }
-
-      .site-header {
-        position: static;
-      }
-    }
-  </style>
+  <link rel="stylesheet" href="styles.css">
 </head>
-<body data-api-base="http://localhost:5000">
-  <header class="site-header">
-    <div class="logo-area">
-      <span class="logo-area__eyebrow" data-i18n="tagline">Медицинская электронная библиотека</span>
-      <h1 class="logo-area__title" data-i18n="heroTitle">Каталог медицинских книг</h1>
-    </div>
-    <div class="language-switcher">
-      <label for="language-select" data-i18n="languageLabel">Язык интерфейса:</label>
-      <select id="language-select" aria-label="Select interface language">
-        <option value="tm">Türkmençe</option>
-        <option value="ru" selected>Русский</option>
-        <option value="en">English</option>
-      </select>
-    </div>
-  </header>
-  <nav aria-label="Primary">
-    <a href="index.html" data-i18n="navHome">Главная</a>
-    <a href="BookCategory.html" data-i18n="navCategories">Категории</a>
-    <a href="book.html" aria-current="page" data-i18n="navBooks">Каталог книг</a>
-    <a href="https://sites.google.com/view/lukmanylyksanlykitaphanasy/ba%C5%9F-sahypa" target="_blank" rel="noopener" data-i18n="navAltSite">Другой сайт библиотеки</a>
-  </nav>
-  <main>
+
+<body class="page" data-api-base="http://localhost:5000">
+  <div class="page">
+    <header class="site-header">
+      <div class="container site-header__bar">
+        <div class="site-header__brand">
+          <p class="eyebrow" data-i18n="tagline">Медицинская электронная библиотека</p>
+          <h1 class="site-header__title" data-i18n="heroTitle">Каталог медицинских книг</h1>
+        </div>
+        <div class="site-header__actions language-switcher">
+          <label for="language-select" data-i18n="languageLabel">Язык интерфейса:</label>
+          <select id="language-select" aria-label="Select interface language">
+            <option value="tm" selected>Türkmençe</option>
+            <option value="ru">Русский</option>
+            <option value="en">English</option>
+          </select>
+        </div>
+      </div>
+      <nav class="site-nav" aria-label="Основная навигация">
+        <div class="container site-nav__wrap">
+          <a href="index.html" data-i18n="navHome">Главная</a>
+          <a href="BookCategory.html" data-i18n="navCategories">Категории</a>
+          <a href="book.html" aria-current="page" data-i18n="navBooks">Каталог книг</a>
+          <a href="https://sites.google.com/view/lukmanylyksanlykitaphanasy/ba%C5%9F-sahypa" target="_blank" rel="noopener" data-i18n="navAltSite">Другой сайт библиотеки</a>
+        </div>
+      </nav>
+    </header>
+    <main class="container book-shell">
     <section class="filter-panel" aria-labelledby="filter-title">
       <div class="filter-panel__head">
         <p class="logo-area__eyebrow" data-i18n="filterEyebrow">Фильтр книг</p>
@@ -446,24 +76,25 @@
     </section>
     <section id="book-grid" class="book-grid" aria-live="polite"></section>
   </main>
-  <footer>
-    <div class="footer-content">
-      <div>
-        <strong data-i18n="contactTitle">Контакты</strong>
-        <p><span data-i18n="contactPhone">Телефон:</span> <a href="tel:+99362234094">+993 62 23 40 94</a></p>
-        <p><span data-i18n="contactEmail">Email:</span> <a href="mailto:tdlipf@gmail.com">tdlipf@gmail.com</a></p>
+    <footer class="site-footer">
+      <div class="container site-footer__content">
+        <div>
+          <strong data-i18n="contactTitle">Контакты</strong>
+          <p><span data-i18n="contactPhone">Телефон:</span> <a href="tel:+99362234094">+993 62 23 40 94</a></p>
+          <p><span data-i18n="contactEmail">Email:</span> <a href="mailto:tdlipf@gmail.com">tdlipf@gmail.com</a></p>
+        </div>
+        <div>
+          <strong data-i18n="footerNavigation">Навигация</strong>
+          <p><a href="index.html" data-i18n="navHome">Главная</a></p>
+          <p><a href="BookCategory.html" data-i18n="navCategories">Категории</a></p>
+        </div>
+        <div>
+          <strong data-i18n="footerRights">© 2025 Медицинская электронная библиотека</strong>
+          <p data-i18n="footerText">Все права защищены. Проект создан для удобного доступа к медицинской литературе.</p>
+        </div>
       </div>
-      <div>
-        <strong data-i18n="footerNavigation">Навигация</strong>
-        <p><a href="index.html" data-i18n="navHome">Главная</a></p>
-        <p><a href="BookCategory.html" data-i18n="navCategories">Категории</a></p>
-      </div>
-      <div>
-        <strong data-i18n="footerRights">© 2025 Медицинская электронная библиотека</strong>
-        <p data-i18n="footerText">Все права защищены. Проект создан для удобного доступа к медицинской литературе.</p>
-      </div>
-    </div>
-  </footer>
+    </footer>
+  </div>
   <script src="https://cdn.jsdelivr.net/npm/xlsx@0.19.3/dist/xlsx.full.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script src="https://cdn.jsdelivr.net/npm/jszip@3.10.1/dist/jszip.min.js" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
   <script>

--- a/db-catalog.html
+++ b/db-catalog.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ru">
+<html lang="tm" data-lang="tm">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -12,98 +12,110 @@
   <link rel="stylesheet" href="styles.css">
   <link rel="manifest" href="manifest.webmanifest">
 </head>
-<body>
-  <header class="site-header">
-    <div class="site-header__brand">
-      <p class="eyebrow">MedLibrary</p>
-      <h1 class="site-header__title">Каталог из базы данных</h1>
-      <p class="site-header__subtitle">dbMedicalLib.sqlite → категории, книги и быстрый поиск</p>
-    </div>
-    <div class="site-header__actions">
-      <a class="button button--ghost" href="BookCategory.html">Категории</a>
-      <a class="button button--outline" href="book.html">Каталог JSON</a>
-    </div>
-    <nav class="site-nav" aria-label="Основная навигация">
-      <a href="index.html">Главная</a>
-      <a href="BookCategory.html">Категории</a>
-      <a href="book.html">Каталог</a>
-      <a href="db-catalog.html" aria-current="page">Каталог БД</a>
-    </nav>
-  </header>
+<body class="page">
+  <div class="page">
+    <header class="site-header">
+      <div class="container site-header__bar">
+        <div class="site-header__brand">
+          <p class="eyebrow" data-i18n="brandEyebrow">MedLibrary</p>
+          <h1 class="site-header__title" data-i18n="brandTitle">Каталог из базы данных</h1>
+          <p class="site-header__lead" data-i18n="brandLead">dbMedicalLib.sqlite → категории, книги и быстрый поиск</p>
+        </div>
+        <div class="site-header__actions language-switcher">
+          <label for="language-select" data-i18n="languageLabel">Язык</label>
+          <select id="language-select" aria-label="Сменить язык">
+            <option value="tm" selected>Türkmençe</option>
+            <option value="ru">Русский</option>
+            <option value="en">English</option>
+          </select>
+        </div>
+      </div>
+      <nav class="site-nav" aria-label="Основная навигация">
+        <div class="container site-nav__wrap">
+          <a href="index.html" data-i18n="navHome">Главная</a>
+          <a href="BookCategory.html" data-i18n="navCategories">Категории</a>
+          <a href="book.html" data-i18n="navJson">Каталог JSON</a>
+          <a href="db-catalog.html" aria-current="page" data-i18n="navDb">Каталог БД</a>
+        </div>
+      </nav>
+    </header>
 
-  <main class="sqlite-shell">
+    <main class="container sqlite-shell">
     <section class="section">
       <div class="sqlite-hero">
         <div>
-          <h2 class="section__title">Интегрированные категории и книги</h2>
-          <p class="section__subtitle">Данные берутся напрямую из dbMedicalLib.sqlite. Фильтруйте по названию, авторам, категориям, языку и году.</p>
+          <h2 class="section__title" data-i18n="heroTitle">Integrirlenen kategoriýalar we kitaplar</h2>
+          <p class="section__subtitle" data-i18n="heroSubtitle">Maglumatlar gönüden-göni dbMedicalLib.sqlite bazasyndan alynýar: ady, awtory, kategoriýasy, dili we ýyly boýunça filtrleň.</p>
           <div class="sqlite-stats" aria-live="polite">
             <div class="stat-card">
-              <p class="stat-label">Книг</p>
-              <p class="stat-value" data-books-count>—</p>
+              <p class="stat-card__label" data-i18n="statsBooks">Kitaplar</p>
+              <p class="stat-card__value" data-books-count>—</p>
             </div>
             <div class="stat-card">
-              <p class="stat-label">Категорий</p>
-              <p class="stat-value" data-categories-count>—</p>
+              <p class="stat-card__label" data-i18n="statsCategories">Kategoriýalar</p>
+              <p class="stat-card__value" data-categories-count>—</p>
             </div>
           </div>
         </div>
         <div class="sqlite-panel">
-          <p class="panel-title">Поиск</p>
+          <p class="panel-title" data-i18n="panelTitle">Gözleg</p>
           <div class="panel-grid">
             <label class="panel-field">
-              <span>Свободный поиск</span>
-              <input type="search" placeholder="Название, автор, ISBN..." data-search-input>
+              <span data-i18n="freeSearchLabel">Erkin gözleg</span>
+              <input type="search" data-i18n-placeholder="freeSearchPlaceholder" placeholder="Ady, awtor, ISBN..." data-search-input>
             </label>
             <label class="panel-field">
-              <span>Категория</span>
+              <span data-i18n="categoryLabel">Kategoriýa</span>
               <select data-category-filter>
-                <option value="">Все категории</option>
+                <option value="" data-i18n="categoryAny">Ähli kategoriýalar</option>
               </select>
             </label>
             <label class="panel-field">
-              <span>Язык</span>
+              <span data-i18n="languageLabelShort">Dil</span>
               <select data-language-filter>
-                <option value="">Любой</option>
+                <option value="" data-i18n="languageAny">Islendik</option>
               </select>
             </label>
           </div>
-          <p class="panel-hint" data-filter-status>Загружаем каталог...</p>
+          <p class="panel-hint" data-filter-status data-i18n="statusLoading">Katalog ýüklenýär...</p>
         </div>
       </div>
     </section>
 
     <section class="section">
       <div class="section__head section__head--tight">
-        <h3 class="section__title">Категории</h3>
-        <p class="section__subtitle">Щёлкните по категории, чтобы сузить выдачу.</p>
+        <h3 class="section__title" data-i18n="categoriesTitle">Kategoriýalar</h3>
+        <p class="section__subtitle" data-i18n="categoriesSubtitle">Netijäni çalt gysgatmak üçin kategoriýa boýunça saýlaň.</p>
       </div>
       <div class="sqlite-category-grid" data-category-list>
-        <p class="muted">Загружаем список направлений...</p>
+        <p class="muted" data-i18n="categoriesLoading">Ugry sanawyny ýükleýäris...</p>
       </div>
     </section>
 
     <section class="section">
       <div class="section__head section__head--tight">
-        <h3 class="section__title">Книги</h3>
-        <p class="section__subtitle">Показываем совпадения по выбранным фильтрам.</p>
+        <h3 class="section__title" data-i18n="booksTitle">Kitaplar</h3>
+        <p class="section__subtitle" data-i18n="booksSubtitle">Saýlanan süzgüçlere görä görkezilýär.</p>
       </div>
       <div class="sqlite-book-grid" data-book-grid>
-        <div class="sqlite-placeholder">Ожидаем данные из базы...</div>
+        <div class="sqlite-placeholder" data-i18n="booksPlaceholder">Bazadan maglumatlary garaşýarys...</div>
       </div>
     </section>
   </main>
 
-  <footer class="site-footer">
-    <div>
-      <strong>© 2025 MedLibrary</strong>
-      <p>Медицинская электронная библиотека. Все права защищены.</p>
-    </div>
-    <div class="site-footer__links">
-      <a href="index.html">Главная</a>
-      <a href="book.html">Каталог JSON</a>
-    </div>
-  </footer>
+    <footer class="site-footer">
+      <div class="container site-footer__content">
+        <div>
+          <strong data-i18n="footerTitle">© 2025 MedLibrary</strong>
+          <p data-i18n="footerText">Lukmançylyk elektron kitaphanasy. Ähli hukuklar goralan.</p>
+        </div>
+        <div class="site-footer__links">
+          <a href="index.html" data-i18n="navHome">Главная</a>
+          <a href="book.html" data-i18n="navJson">Каталог JSON</a>
+        </div>
+      </div>
+    </footer>
+  </div>
 
   <script defer src="db-catalog.js"></script>
   <script defer src="pwa.js"></script>

--- a/db-catalog.js
+++ b/db-catalog.js
@@ -1,3 +1,159 @@
+const translations = {
+  tm: {
+    pageTitle: "BD katalogy — MedLibrary",
+    brandEyebrow: "MedLibrary",
+    brandTitle: "Bazada ýerleşýän katalog",
+    brandLead: "dbMedicalLib.sqlite – kategoriýalar, kitaplar we çalt gözleg",
+    navHome: "Baş sahypa",
+    navCategories: "Kategoriýalar",
+    navJson: "JSON katalogy",
+    navDb: "BD katalogy",
+    languageLabel: "Dil",
+    heroTitle: "Integrirlenen kategoriýalar we kitaplar",
+    heroSubtitle:
+      "Maglumatlar gönüden-göni dbMedicalLib.sqlite bazasyndan alynýar: ady, awtory, kategoriýasy, dili we ýyly boýunça filtrleň.",
+    statsBooks: "Kitaplar",
+    statsCategories: "Kategoriýalar",
+    panelTitle: "Gözleg",
+    freeSearchLabel: "Erkin gözleg",
+    freeSearchPlaceholder: "Ady, awtor, ISBN...",
+    categoryLabel: "Kategoriýa",
+    categoryAny: "Ähli kategoriýalar",
+    languageLabelShort: "Dil",
+    languageAny: "Islendik",
+    statusLoading: "Katalog ýüklenýär...",
+    catalogEmpty: "Katalog boş",
+    statusFound: "{shown} / {total} kitap görkezilýär",
+    filterNoResults: "Görnüşlere laýyk kitap tapylmady",
+    untitled: "Ady ýok",
+    metaAuthor: "Awtor",
+    metaPublisher: "Neşirçi",
+    metaCity: "Şäher",
+    metaYear: "Ýyl",
+    metaPages: "Sah.",
+    metaPagesLabel: "Sahypa",
+    metaLanguage: "Dil",
+    metaIsbn: "ISBN",
+    metaUdk: "UDK",
+    metaBbk: "BBK",
+    categoriesEmpty: "Kategoriýalar tapylmady",
+    categoryCount: "{count} kitap",
+    categoriesTitle: "Kategoriýalar",
+    categoriesSubtitle: "Netijäni çalt gysgatmak üçin kategoriýa boýunça saýlaň.",
+    categoriesLoading: "Ugry sanawyny ýükleýäris...",
+    booksTitle: "Kitaplar",
+    booksSubtitle: "Saýlanan süzgüçlere görä görkezilýär.",
+    booksPlaceholder: "Bazadan maglumatlary garaşýarys...",
+    loadError: "dbMedicalLib.sqlite bilen maglumat ýüklenmedi",
+    optionAny: "Islendik",
+    footerTitle: "© 2025 MedLibrary",
+    footerText: "Lukmançylyk elektron kitaphanasy. Ähli hukuklar goralan.",
+  },
+  ru: {
+    pageTitle: "Каталог БД — MedLibrary",
+    brandEyebrow: "MedLibrary",
+    brandTitle: "Каталог из базы данных",
+    brandLead: "dbMedicalLib.sqlite — категории, книги и быстрый поиск",
+    navHome: "Главная",
+    navCategories: "Категории",
+    navJson: "Каталог JSON",
+    navDb: "Каталог БД",
+    languageLabel: "Язык",
+    heroTitle: "Интегрированные категории и книги",
+    heroSubtitle:
+      "Данные берутся напрямую из dbMedicalLib.sqlite. Фильтруйте по названию, авторам, категориям, языку и году.",
+    statsBooks: "Книг",
+    statsCategories: "Категорий",
+    panelTitle: "Поиск",
+    freeSearchLabel: "Свободный поиск",
+    freeSearchPlaceholder: "Название, автор, ISBN...",
+    categoryLabel: "Категория",
+    categoryAny: "Все категории",
+    languageLabelShort: "Язык",
+    languageAny: "Любой",
+    statusLoading: "Загружаем каталог...",
+    catalogEmpty: "Каталог пуст",
+    statusFound: "Найдено {shown} из {total} книг",
+    filterNoResults: "Нет совпадений по заданным фильтрам.",
+    untitled: "Без названия",
+    metaAuthor: "Автор",
+    metaPublisher: "Издатель",
+    metaCity: "Город",
+    metaYear: "Год",
+    metaPages: "стр.",
+    metaPagesLabel: "Страниц",
+    metaLanguage: "Язык",
+    metaIsbn: "ISBN",
+    metaUdk: "УДК",
+    metaBbk: "ББК",
+    categoriesEmpty: "Категории не найдены",
+    categoryCount: "{count} книг",
+    categoriesTitle: "Категории",
+    categoriesSubtitle: "Щёлкните по категории, чтобы сузить выдачу.",
+    categoriesLoading: "Загружаем список направлений...",
+    booksTitle: "Книги",
+    booksSubtitle: "Показываем совпадения по выбранным фильтрам.",
+    booksPlaceholder: "Ожидаем данные из базы...",
+    loadError: "Не удалось загрузить dbMedicalLib.sqlite",
+    optionAny: "Любой",
+    footerTitle: "© 2025 MedLibrary",
+    footerText: "Медицинская электронная библиотека. Все права защищены.",
+  },
+  en: {
+    pageTitle: "DB catalogue — MedLibrary",
+    brandEyebrow: "MedLibrary",
+    brandTitle: "Database catalogue",
+    brandLead: "dbMedicalLib.sqlite — categories, books, and fast filters",
+    navHome: "Home",
+    navCategories: "Categories",
+    navJson: "JSON catalog",
+    navDb: "DB catalog",
+    languageLabel: "Language",
+    heroTitle: "Integrated categories and books",
+    heroSubtitle:
+      "Data comes directly from dbMedicalLib.sqlite. Filter by title, author, category, language, and year.",
+    statsBooks: "Books",
+    statsCategories: "Categories",
+    panelTitle: "Search",
+    freeSearchLabel: "Free search",
+    freeSearchPlaceholder: "Title, author, ISBN...",
+    categoryLabel: "Category",
+    categoryAny: "All categories",
+    languageLabelShort: "Language",
+    languageAny: "Any",
+    statusLoading: "Loading catalog...",
+    catalogEmpty: "Catalog is empty",
+    statusFound: "Showing {shown} of {total} books",
+    filterNoResults: "No matches for current filters.",
+    untitled: "Untitled",
+    metaAuthor: "Author",
+    metaPublisher: "Publisher",
+    metaCity: "City",
+    metaYear: "Year",
+    metaPages: "pages",
+    metaPagesLabel: "Pages",
+    metaLanguage: "Language",
+    metaIsbn: "ISBN",
+    metaUdk: "UDC",
+    metaBbk: "BBK",
+    categoriesEmpty: "No categories found",
+    categoryCount: "{count} books",
+    categoriesTitle: "Categories",
+    categoriesSubtitle: "Click a category to narrow the list.",
+    categoriesLoading: "Loading categories...",
+    booksTitle: "Books",
+    booksSubtitle: "Filtered results.",
+    booksPlaceholder: "Waiting for data from the database...",
+    loadError: "Failed to load dbMedicalLib.sqlite",
+    optionAny: "Any",
+    footerTitle: "© 2025 MedLibrary",
+    footerText: "Medical digital library. All rights reserved.",
+  },
+};
+
+let activeLang =
+  document.documentElement.dataset.lang || document.documentElement.lang || "tm";
+
 const state = {
   catalog: null,
   filteredBooks: [],
@@ -8,6 +164,40 @@ const state = {
 
 const elements = {};
 let apiBase = "";
+
+const t = (key) =>
+  translations[activeLang]?.[key] ??
+  translations.tm?.[key] ??
+  translations.ru?.[key] ??
+  "";
+
+const applyTranslations = () => {
+  document.documentElement.lang = activeLang;
+  document.documentElement.dataset.lang = activeLang;
+  document.title = t("pageTitle") || document.title;
+
+  document.querySelectorAll("[data-i18n]").forEach((node) => {
+    const key = node.dataset.i18n;
+    const value = t(key);
+    if (value) {
+      node.textContent = value;
+    }
+  });
+
+  document.querySelectorAll("[data-i18n-placeholder]").forEach((node) => {
+    const key = node.dataset.i18nPlaceholder;
+    const value = t(key);
+    if (value) {
+      node.placeholder = value;
+    }
+  });
+
+  if (state.catalog) {
+    populateFilters();
+    updateStatus();
+    renderBooks();
+  }
+};
 
 const normalizeValue = (value) =>
   value == null
@@ -31,7 +221,7 @@ const resolveApiBase = () => {
 
 const formatPages = (pages) => {
   if (!pages) return "";
-  return `${pages} стр.`;
+  return `${pages} ${t("metaPages")}`;
 };
 
 const updateStatus = () => {
@@ -39,10 +229,11 @@ const updateStatus = () => {
   const total = state.catalog.books.length;
   const shown = state.filteredBooks.length;
   if (total === 0) {
-    elements.filterStatus.textContent = "Каталог пуст";
+    elements.filterStatus.textContent = t("catalogEmpty");
     return;
   }
-  elements.filterStatus.textContent = `Найдено ${shown} из ${total} книг`;
+  elements.filterStatus.textContent =
+    t("statusFound").replace("{shown}", shown).replace("{total}", total);
 };
 
 const renderBooks = () => {
@@ -52,7 +243,7 @@ const renderBooks = () => {
   if (!state.filteredBooks.length) {
     const placeholder = document.createElement("div");
     placeholder.className = "sqlite-placeholder";
-    placeholder.textContent = "Нет совпадений по заданным фильтрам.";
+    placeholder.textContent = t("filterNoResults");
     elements.bookGrid.appendChild(placeholder);
     return;
   }
@@ -65,7 +256,7 @@ const renderBooks = () => {
 
     const title = document.createElement("h4");
     title.className = "sqlite-card__title";
-    title.textContent = book.titleRu || book.titleTm || "Без названия";
+    title.textContent = book.titleRu || book.titleTm || t("untitled");
     card.appendChild(title);
 
     if (book.titleTm && book.titleRu && book.titleTm !== book.titleRu) {
@@ -79,15 +270,15 @@ const renderBooks = () => {
     metaList.className = "sqlite-card__meta";
 
     const metaItems = [
-      ["Автор", book.authorRu || book.authorTm],
-      ["Издатель", book.publisher],
-      ["Город", book.city],
-      ["Год", book.year],
-      ["Страниц", formatPages(book.pages)],
-      ["Язык", book.language],
-      ["ISBN", book.isbn],
-      ["УДК", book.udk],
-      ["ББК", book.bbk],
+      [t("metaAuthor"), book.authorRu || book.authorTm],
+      [t("metaPublisher"), book.publisher],
+      [t("metaCity"), book.city],
+      [t("metaYear"), book.year],
+      [t("metaPagesLabel"), formatPages(book.pages)],
+      [t("metaLanguage"), book.language],
+      [t("metaIsbn"), book.isbn],
+      [t("metaUdk"), book.udk],
+      [t("metaBbk"), book.bbk],
     ];
 
     metaItems.forEach(([label, value]) => {
@@ -137,7 +328,7 @@ const renderCategoryCards = () => {
   if (!state.catalog.categories.length) {
     const placeholder = document.createElement("p");
     placeholder.className = "muted";
-    placeholder.textContent = "Категории не найдены";
+    placeholder.textContent = t("categoriesEmpty");
     elements.categoryList.appendChild(placeholder);
     return;
   }
@@ -156,11 +347,11 @@ const renderCategoryCards = () => {
 
     const title = document.createElement("span");
     title.className = "category-chip__title";
-    title.textContent = category.nameRu || category.nameTm || "Без названия";
+    title.textContent = category.nameRu || category.nameTm || t("untitled");
 
     const count = document.createElement("span");
     count.className = "category-chip__count";
-    count.textContent = `${category.count} книг`;
+    count.textContent = t("categoryCount").replace("{count}", category.count);
 
     button.append(title, count);
     button.addEventListener("click", () => {
@@ -227,7 +418,12 @@ const populateFilters = () => {
   }
 
   if (elements.categoryFilter) {
-    elements.categoryFilter.innerHTML = '<option value="">Все категории</option>';
+    const selected = elements.categoryFilter.value;
+    elements.categoryFilter.innerHTML = "";
+    const anyOption = document.createElement("option");
+    anyOption.value = "";
+    anyOption.textContent = t("categoryAny");
+    elements.categoryFilter.appendChild(anyOption);
     state.catalog.categories.forEach((category) => {
       const option = document.createElement("option");
       const normalized = normalizeCategoryValue(category);
@@ -235,10 +431,16 @@ const populateFilters = () => {
       option.textContent = category.nameRu || category.nameTm;
       elements.categoryFilter.appendChild(option);
     });
+    elements.categoryFilter.value = selected;
   }
 
   if (elements.languageFilter) {
-    elements.languageFilter.innerHTML = '<option value="">Любой</option>';
+    const selected = elements.languageFilter.value;
+    elements.languageFilter.innerHTML = "";
+    const anyOption = document.createElement("option");
+    anyOption.value = "";
+    anyOption.textContent = t("languageAny");
+    elements.languageFilter.appendChild(anyOption);
     const languages = Array.from(
       new Set(
         state.catalog.books
@@ -262,6 +464,7 @@ const populateFilters = () => {
         option.textContent = display;
         elements.languageFilter.appendChild(option);
       });
+    elements.languageFilter.value = selected;
   }
 
   renderCategoryCards();
@@ -285,7 +488,7 @@ const attachEvents = () => {
 
 const fetchCatalog = async () => {
   if (!elements.filterStatus) return;
-  elements.filterStatus.textContent = "Загружаем каталог...";
+  elements.filterStatus.textContent = t("statusLoading");
 
   try {
     const endpoint = apiBase ? `${apiBase}/db/catalog` : "/db/catalog";
@@ -296,17 +499,15 @@ const fetchCatalog = async () => {
     const catalog = await response.json();
     state.catalog = catalog;
     state.filteredBooks = catalog.books;
-    populateFilters();
-    updateStatus();
-    renderBooks();
+    applyTranslations();
   } catch (error) {
     console.warn(error);
-    elements.filterStatus.textContent = "Не удалось загрузить каталог";
+    elements.filterStatus.textContent = t("loadError");
     if (elements.bookGrid) {
       elements.bookGrid.innerHTML = "";
       const notice = document.createElement("div");
       notice.className = "sqlite-placeholder";
-      notice.textContent = "Ошибка загрузки данных из dbMedicalLib.sqlite";
+      notice.textContent = t("loadError");
       elements.bookGrid.appendChild(notice);
     }
     return;
@@ -322,12 +523,24 @@ const init = () => {
   elements.bookGrid = document.querySelector("[data-book-grid]");
   elements.booksCount = document.querySelector("[data-books-count]");
   elements.categoriesCount = document.querySelector("[data-categories-count]");
+  elements.languageSelect = document.getElementById("language-select");
 
   apiBase = resolveApiBase();
   if (document.body) {
     document.body.dataset.apiBase = apiBase;
   }
 
+  if (elements.languageSelect) {
+    if (elements.languageSelect.value !== activeLang) {
+      elements.languageSelect.value = activeLang;
+    }
+    elements.languageSelect.addEventListener("change", (event) => {
+      activeLang = event.target.value || "tm";
+      applyTranslations();
+    });
+  }
+
+  applyTranslations();
   attachEvents();
   fetchCatalog();
 };

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="ru" data-lang="ru">
+<html lang="tm" data-lang="tm">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">

--- a/scripts.js
+++ b/scripts.js
@@ -273,7 +273,7 @@ function initLanguageSwitcher() {
   }
 
   const changeLanguage = () => {
-    const lang = languageSelect.value || documentLang || "ru";
+    const lang = languageSelect.value || documentLang || "tm";
     document.documentElement.dataset.lang = lang;
     document.documentElement.lang = lang;
     document.querySelectorAll(".lang").forEach((element) => {

--- a/styles.css
+++ b/styles.css
@@ -856,3 +856,234 @@ main {
   .site-footer__content { flex-direction: column; align-items: flex-start; }
   .gallery-slider__control { display: none; }
 }
+
+/* Book catalog layout */
+.book-shell { display: grid; gap: 1.5rem; padding-block: clamp(1.5rem, 4vw, 2.5rem); }
+
+.language-switcher { display: flex; align-items: center; gap: 0.5rem; }
+
+.language-switcher label { font-weight: 600; color: var(--muted); }
+
+.filter-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: clamp(1.1rem, 3vw, 1.75rem);
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 1rem;
+}
+
+.filter-panel__head { display: grid; gap: 0.35rem; }
+.filter-panel__title { margin: 0; font-size: clamp(1.35rem, 3vw, 1.7rem); }
+.filter-panel__subtitle { margin: 0; color: var(--muted); }
+
+.filter-form {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 0.85rem;
+}
+
+.filter-field { display: grid; gap: 0.35rem; font-weight: 600; color: var(--muted); }
+
+.filter-field input {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.75rem 0.85rem;
+  font-size: 1rem;
+  color: var(--text);
+  background: #fff;
+  box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.04);
+}
+
+.filter-actions { display: flex; gap: 0.75rem; flex-wrap: wrap; }
+
+.status-bar { display: flex; align-items: center; gap: 0.6rem; }
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  background: var(--surface-soft);
+  color: var(--primary);
+  font-weight: 700;
+  border: 1px solid rgba(26, 108, 255, 0.25);
+}
+
+.book-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+  gap: 1rem;
+}
+
+.book-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.85rem;
+  box-shadow: var(--shadow);
+}
+
+.book-card__header { display: grid; gap: 0.25rem; }
+
+.book-card__title { margin: 0; font-size: 1.15rem; color: var(--text); }
+
+.book-card__meta { color: var(--muted); margin: 0; }
+
+.book-card__details {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 0.5rem;
+  font-size: 0.96rem;
+  color: var(--muted);
+}
+
+.book-card__label { color: var(--text); font-weight: 700; margin-right: 0.35rem; }
+
+.badge-grid { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.4rem 0.75rem;
+  border-radius: 999px;
+  background: var(--surface-soft);
+  color: var(--primary);
+  border: 1px solid rgba(26, 108, 255, 0.2);
+  font-weight: 700;
+}
+
+.badge__icon { opacity: 0.65; }
+
+.book-card__actions { display: flex; gap: 0.6rem; flex-wrap: wrap; }
+
+.book-card__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.75rem 0.9rem;
+  border-radius: 12px;
+  text-decoration: none;
+  background: linear-gradient(120deg, var(--primary), var(--primary-2));
+  color: #fff;
+  font-weight: 700;
+  box-shadow: 0 12px 25px rgba(26, 108, 255, 0.18);
+  border: 1px solid rgba(26, 108, 255, 0.18);
+}
+
+.book-card__link:hover { transform: translateY(-1px); }
+.book-card__link[aria-disabled="true"] { opacity: 0.65; cursor: not-allowed; box-shadow: none; }
+
+.empty-state {
+  grid-column: 1 / -1;
+  background: rgba(26, 108, 255, 0.08);
+  color: var(--primary);
+  padding: 2rem;
+  border-radius: 24px;
+  text-align: center;
+  font-weight: 600;
+}
+
+@media (max-width: 720px) {
+  .book-card__details { grid-template-columns: 1fr; }
+}
+
+/* SQLite catalog layout */
+.sqlite-shell { display: grid; gap: 1.5rem; padding-block: clamp(1.5rem, 4vw, 2.5rem); }
+
+.sqlite-hero {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  gap: 1rem;
+  align-items: start;
+}
+
+.sqlite-stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 0.75rem; margin-top: 0.5rem; }
+
+.sqlite-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1rem;
+  box-shadow: var(--shadow);
+  display: grid;
+  gap: 0.75rem;
+}
+
+.panel-title { margin: 0; font-weight: 800; font-size: 1.05rem; }
+.panel-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap: 0.85rem; }
+.panel-field { display: grid; gap: 0.3rem; font-weight: 600; color: var(--muted); }
+
+.panel-field input,
+.panel-field select {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 0.7rem 0.9rem;
+  font-size: 1rem;
+  color: var(--text);
+  background: #fff;
+  box-shadow: inset 0 1px 0 rgba(15, 23, 42, 0.04);
+}
+
+.panel-hint { margin: 0; color: var(--muted); }
+
+.sqlite-category-grid { display: flex; flex-wrap: wrap; gap: 0.5rem; }
+
+.category-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0.55rem 0.9rem;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: var(--surface-soft);
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+.category-chip--active { border-color: rgba(26, 108, 255, 0.35); box-shadow: 0 12px 25px rgba(26, 108, 255, 0.12); }
+.category-chip__title { font-weight: 700; color: var(--text); }
+.category-chip__count { color: var(--muted); font-size: 0.9rem; }
+
+.sqlite-book-grid { display: grid; grid-template-columns: repeat(auto-fit, minmax(280px, 1fr)); gap: 1rem; }
+
+.sqlite-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.6rem;
+  box-shadow: var(--shadow);
+}
+
+.sqlite-card__title { margin: 0; font-size: 1.05rem; }
+.sqlite-card__subtitle { margin: 0; color: var(--muted); }
+
+.sqlite-card__meta {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.35rem 0.65rem;
+  margin: 0;
+}
+
+.sqlite-card__meta dt { color: var(--muted); font-weight: 600; }
+.sqlite-card__meta dd { margin: 0; font-weight: 700; }
+
+.sqlite-card__tags { display: flex; flex-wrap: wrap; gap: 0.35rem; }
+.tag { display: inline-flex; align-items: center; padding: 0.3rem 0.7rem; border-radius: 999px; background: var(--surface-soft); color: var(--primary); border: 1px solid rgba(26, 108, 255, 0.2); font-weight: 600; }
+
+.sqlite-placeholder {
+  padding: 1rem;
+  border: 1px dashed var(--border);
+  border-radius: 12px;
+  color: var(--muted);
+  background: var(--surface-soft);
+}


### PR DESCRIPTION
## Summary
- set Turkmen as the default language across the site and language selectors
- rework the book and DB catalog pages to use the shared layout/styling for consistent appearance
- add multilingual strings and translations for the DB catalog while keeping the SQLite-powered catalogue

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a05622888329bc00172fe3d3ab3a)