### PR TITLE
Improve mobile layout responsiveness

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -382,7 +382,7 @@ main {
 
 .section--split {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
   gap: 1.25rem;
   align-items: start;
 }
@@ -992,6 +992,45 @@ main {
 
 @media (max-width: 720px) {
   .book-card__details { grid-template-columns: 1fr; }
+}
+
+@media (max-width: 720px) {
+  .site-nav__wrap {
+    flex-wrap: nowrap;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+    scrollbar-width: none;
+    gap: 0.4rem;
+  }
+
+  .site-nav__wrap::-webkit-scrollbar {
+    display: none;
+  }
+
+  .site-nav a {
+    flex: 0 0 auto;
+  }
+}
+
+@media (max-width: 540px) {
+  main {
+    padding-block: clamp(1.5rem, 6vw, 2rem);
+    gap: clamp(2rem, 5vw, 2.75rem);
+  }
+
+  .hero__content,
+  .accent-card,
+  .section,
+  .filter-panel {
+    padding: clamp(1rem, 5vw, 1.25rem);
+  }
+
+  .hero__layout,
+  .section--split,
+  .feature-grid,
+  .sqlite-hero {
+    grid-template-columns: 1fr;
+  }
 }
 
 /* SQLite catalog layout */


### PR DESCRIPTION
## Summary
- reduce minimum column widths and padding to avoid overflow on narrow screens
- add mobile-specific adjustments for navigation scrolling and single-column layouts

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922a75debc88329aac6b8f4cc6bd22e)