### PR TITLE
Fix auth preflight and close modal after login

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -605,7 +605,7 @@ function initLoginForm(apiBase, modalControls = {}) {
       }
       clearLocalSession();
       setStatusMessage(statusElement, data?.message || "Вход выполнен", "success");
-      refreshSession(false);
+      await refreshSession(false);
       form.reset();
       closeModal();
     } catch (error) {

--- a/server.js
+++ b/server.js
@@ -437,6 +437,10 @@ const app = express();
 
 app.use(helmet());
 app.use(cors());
+// Явно разрешаем preflight-запросы для всех маршрутов, чтобы браузеры не
+// получали ошибку 405 при попытке обратиться к API авторизации с других
+// источников.
+app.options("*", cors());
 app.use(express.json());
 app.use(morgan("tiny"));
 


### PR DESCRIPTION
## Summary
- add explicit OPTIONS handling so auth endpoints accept preflight requests
- ensure the auth modal closes after a successful login refresh sequence

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922aa4b772c8329969263b0003feb13)