### PR TITLE
Ensure book cover images fit card layout

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -929,6 +929,24 @@ main {
   box-shadow: var(--shadow);
 }
 
+.book-card__media {
+  width: 100%;
+  aspect-ratio: 3 / 4;
+  border-radius: 14px;
+  overflow: hidden;
+  background: var(--surface-soft);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.book-card__media img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
 .book-card__header { display: grid; gap: 0.25rem; }
 
 .book-card__title { margin: 0; font-size: 1.15rem; color: var(--text); }


### PR DESCRIPTION
## Summary
- add layout rules for book card media container to enforce consistent aspect ratio
- ensure cover images fill the container responsively with object-fit cover and centered flex layout

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922ec01cd3c83299603d72cd8506165)