### PR TITLE
Add covers directory for cached book images

### DIFF
--- a/data/covers/README.md
+++ b/data/covers/README.md
@@ -1,0 +1,3 @@
+# Book cover cache
+
+This directory stores cached book cover images downloaded by the API. The files are saved automatically when a cover URL is requested and validated.


### PR DESCRIPTION
## Summary
- add a dedicated data/covers directory for storing cached book cover images used by the API
- document the purpose of the cover cache directory

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6922f337cd5c8329950c061e3f253faf)