### PR TITLE
Improve runtime config and language defaults

### DIFF
--- a/FRONTEND_ANALYSIS.md
+++ b/FRONTEND_ANALYSIS.md
@@ -1,0 +1,22 @@
+# Frontend audit
+
+## Overview
+- The landing page is a single static document with anchors for hero, features, catalog, platform, gallery, and contact sections, plus deep links to the catalog and category listings. Navigation and calls-to-action rely on inline text for three languages. 【F:index.html†L60-L164】
+- Language toggles are implemented by duplicating content in multiple `<span>`/`<p>` blocks that are selectively hidden based on a `data-lang` attribute. 【F:index.html†L34-L164】
+- Runtime configuration is read from `config.js`, which populates API host and Google OAuth client ID data attributes at load time instead of embedding credentials in HTML. 【F:config.js†L1-L35】【F:index.html†L20-L33】
+- PWA support is wired through a service worker registration and custom install prompts that show any button marked with `data-install-trigger`. 【F:pwa.js†L2-L77】【F:index.html†L47-L128】
+
+## Strengths
+- Clear PWA affordances: install buttons appear in the header and hero areas, and the code falls back to opening the manifest if the install prompt is unavailable. 【F:index.html†L47-L128】【F:pwa.js†L32-L36】
+- Navigation is concise and action-oriented, keeping the focus on catalog access and category browsing without clutter. 【F:index.html†L60-L200】
+- Language initialization now respects the saved preference or the current selector value, keeping the dropdown and rendered copy in sync and persisting the choice. 【F:index.html†L34-L45】【F:lang.js†L1-L36】
+
+## Risks & issues
+- Internationalization requires duplicating every string in the markup, which increases page weight and maintenance overhead. A dictionary-based renderer (e.g., JSON locale bundles consumed by JavaScript) would be more scalable and accessible. 【F:index.html†L34-L164】【F:lang.js†L2-L8】
+- Runtime config ships with empty defaults; deployments must inject real API base URLs and OAuth IDs into `window.__APP_CONFIG__` (or query parameters) to keep authentication and catalog APIs functional. Consider providing environment-specific builds or CI substitutions to prevent shipping empty settings. 【F:config.js†L1-L35】
+
+## Recommendations
+- Externalize environment-specific values (API base URL, OAuth client IDs) into configuration files or environment variables that are injected during the build/deploy pipeline rather than hard-coded attributes. 【F:index.html†L20-L33】【F:config.js†L1-L35】
+- Align language initialization with the selected option or persist the user’s preference in storage to avoid conflicting defaults. Replace the current `setLanguage('tm')` call with logic that reads the selector value or a saved preference. 【F:index.html†L34-L45】【F:lang.js†L1-L36】
+- Move translations into JSON locale files and render text via a lightweight i18n utility so that markup stays DRY and future languages do not require tripling every block of content. 【F:index.html†L34-L164】【F:lang.js†L2-L8】
+- Consider lazy-loading heavier catalog assets and deferring non-critical scripts to improve initial render on low-end devices, keeping the landing experience focused on the primary CTAs. 【F:index.html†L74-L200】

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ npm run dev
 
 1. Получите OAuth 2.0 Client ID в [Google Cloud Console](https://console.cloud.google.com/apis/credentials). Для тестов можно использовать тип `Web` и добавить `http://localhost:5000` в список разрешённых источников.
 2. Укажите Client ID в `.env` (переменная `GOOGLE_CLIENT_ID`). Можно перечислить несколько идентификаторов через запятую. При необходимости ограничьте доменом `GOOGLE_ALLOWED_HD=example.com`.
-3. На фронтенде задайте тот же Client ID через атрибут `data-google-client-id` тега `<body>` или мета-тег `<meta name="google-client-id" ...>`. В репозитории уже прописан рабочий идентификатор для стенда.
-4. При необходимости переопределите идентификатор прямо в ссылке: добавьте `?googleClientId=XXX` к `index.html` или `auth.html` (например, `auth.html?apiBase=http://localhost:5000&googleClientId=YYY`). Параметр перекрывает мета-тег и `data-*` атрибут.
+3. На фронтенде задайте тот же Client ID через `config.js`, передав значение в `window.__APP_CONFIG__`. Не храните рабочие ключи в HTML: скрипт настраивает атрибуты `data-google-client-id` и мета-тег уже в браузере.
+4. При необходимости переопределите идентификатор прямо в ссылке: добавьте `?googleClientId=XXX` к `index.html` или `auth.html` (например, `auth.html?apiBase=http://localhost:5000&googleClientId=YYY`). Параметр перекрывает мета-тег и значения из `config.js`.
 5. После этого в блоке авторизации появится кнопка «Войти через Google». Пользователь получает обычный JWT, а сервер создаёт локальную учётную запись автоматически, используя адрес электронной почты из Google.
 
 Отдельная страница `auth.html` использует те же настройки, поэтому достаточно поделиться ссылкой вроде `auth.html?apiBase=https://api.example.com&googleClientId=XXX`.

--- a/auth.html
+++ b/auth.html
@@ -3,10 +3,11 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="google-client-id" content="815759578613-pf7pkrfsc0u70edgykqvku3m0p1wq3p2.apps.googleusercontent.com">
+    <meta name="google-client-id" content="">
     <meta name="theme-color" content="#0d47a1">
     <title>Регистрация и вход</title>
     <link rel="manifest" href="/MedLibrary/manifest.webmanifest">
+    <script src="config.js"></script>
     <style>
         :root {
             font-family: "Inter", "Segoe UI", system-ui, -apple-system, sans-serif;

--- a/config.js
+++ b/config.js
@@ -1,0 +1,31 @@
+// Runtime configuration for MedLibrary front-end
+// Replace values below during deployment to avoid hard-coding credentials in HTML.
+window.__APP_CONFIG__ = window.__APP_CONFIG__ || {
+  apiBase: '',
+  googleClientId: '',
+};
+
+(function applyRuntimeConfig(config) {
+  const applyConfig = () => {
+    const body = document.body;
+    if (!body) return;
+
+    if (config.apiBase) {
+      body.dataset.apiBase = config.apiBase;
+    }
+
+    if (config.googleClientId) {
+      body.dataset.googleClientId = config.googleClientId;
+      const googleMeta = document.querySelector('meta[name="google-client-id"]');
+      if (googleMeta) {
+        googleMeta.content = config.googleClientId;
+      }
+    }
+  };
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', applyConfig, { once: true });
+  } else {
+    applyConfig();
+  }
+})(window.__APP_CONFIG__);

--- a/index.html
+++ b/index.html
@@ -17,16 +17,10 @@
     />
     <link rel="stylesheet" href="styles.css" />
     <link rel="manifest" href="manifest.webmanifest" />
-    <meta
-      name="google-client-id"
-      content="815759578613-pf7pkrfsc0u70edgykqvku3m0p1wq3p2.apps.googleusercontent.com"
-    />
+    <meta name="google-client-id" content="" />
+    <script src="config.js"></script>
   </head>
-  <body
-    class="home"
-    data-api-base="http://localhost:5000"
-    data-google-client-id="815759578613-pf7pkrfsc0u70edgykqvku3m0p1wq3p2.apps.googleusercontent.com"
-  >
+  <body class="home">
     <div class="page">
       <header class="site-header">
         <div class="container site-header__bar">

--- a/lang.js
+++ b/lang.js
@@ -1,13 +1,30 @@
+const LANG_STORAGE_KEY = 'preferredLanguage';
 
 function setLanguage(lang) {
+  document.documentElement.lang = lang;
+  document.documentElement.dataset.lang = lang;
+
   document.querySelectorAll('[data-lang]').forEach(element => {
-    if (element.dataset.lang === lang) {
-      element.hidden = false;
-    } else {
-      element.hidden = true;
-    }
+    element.hidden = element.dataset.lang !== lang;
   });
 }
 
-// Установить язык по умолчанию (например, русский)
-setLanguage('tm');
+function initLanguage() {
+  const languageSelect = document.getElementById('language-select');
+  const savedLanguage = localStorage.getItem(LANG_STORAGE_KEY);
+  const defaultLanguage = languageSelect?.value || 'tm';
+  const initialLanguage = savedLanguage || defaultLanguage;
+
+  setLanguage(initialLanguage);
+
+  if (languageSelect) {
+    languageSelect.value = initialLanguage;
+    languageSelect.addEventListener('change', event => {
+      const selectedLang = event.target.value;
+      setLanguage(selectedLang);
+      localStorage.setItem(LANG_STORAGE_KEY, selectedLang);
+    });
+  }
+}
+
+document.addEventListener('DOMContentLoaded', initLanguage);


### PR DESCRIPTION
## Summary
- add runtime config loader to remove hard-coded API host and Google client ID from HTML
- align language initialization with the visible selector and persist user preference
- update documentation to describe the new config flow and refreshed frontend audit

## Testing
- not run (not requested)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69233a4d6ec88329a279f31ae9fb9de7)