### PR TITLE
Implement JSON-driven language switching

### DIFF
--- a/BookCategory.html
+++ b/BookCategory.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="tm" data-lang="tm">
+<html lang="ru" data-lang="ru">
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
@@ -15,68 +15,54 @@
 <body>
   <header class="site-header">
     <div class="site-header__brand">
-      <p class="eyebrow lang" data-lang="ru">Категории библиотеки</p>
-      <p class="eyebrow lang" data-lang="en">Library categories</p>
-      <p class="eyebrow lang" data-lang="tm">Kategoriýalar</p>
-      <h1 class="site-header__title lang" data-lang="ru">Медицинские направления</h1>
-      <h1 class="site-header__title lang" data-lang="en">Medical specialties</h1>
-      <h1 class="site-header__title lang" data-lang="tm">Lukmançylyk ugurlary</h1>
+      <p class="eyebrow" data-i18n="category.tagline">Категории библиотеки</p>
+      <h1 class="site-header__title" data-i18n="category.title">Медицинские направления</h1>
     </div>
     <div class="site-header__actions">
-      <select id="language-select" aria-label="Сменить язык">
-        <option value="tm" selected>Türkmençe</option>
-        <option value="ru">Русский</option>
-        <option value="en">English</option>
-      </select>
-      <button id="install-button" class="button button--ghost" type="button" hidden data-install-trigger>
-        <span class="lang" data-lang="ru">Скачать приложение</span>
-        <span class="lang" data-lang="en">Download app</span>
-        <span class="lang" data-lang="tm">Programmany ýükläň</span>
+      <nav class="lang-switch" aria-label="Выбор языка">
+        <button type="button" data-lang="tm">TM</button>
+        <button type="button" data-lang="ru">RU</button>
+        <button type="button" data-lang="en">EN</button>
+      </nav>
+      <button id="install-button" class="button button--ghost" type="button" hidden data-install-trigger data-i18n="header.install">
+        Скачать приложение
       </button>
-      <a class="button button--outline" href="book.html">
-        <span class="lang" data-lang="ru">Каталог книг</span>
-        <span class="lang" data-lang="en">Book catalog</span>
-        <span class="lang" data-lang="tm">Kitap katalogy</span>
+      <a class="button button--outline" href="book.html" data-i18n="nav.bookCatalog">
+        Каталог книг
       </a>
     </div>
     <nav class="site-nav" aria-label="Основная навигация">
-      <a href="index.html"><span class="lang" data-lang="ru">Главная</span><span class="lang" data-lang="en">Home</span><span class="lang" data-lang="tm">Baş sahypa</span></a>
-      <a href="BookCategory.html" aria-current="page"><span class="lang" data-lang="ru">Категории</span><span class="lang" data-lang="en">Categories</span><span class="lang" data-lang="tm">Kategoriýalar</span></a>
-      <a href="book.html"><span class="lang" data-lang="ru">Каталог</span><span class="lang" data-lang="en">Catalog</span><span class="lang" data-lang="tm">Katalog</span></a>
+      <a href="index.html" data-i18n="nav.home">Главная</a>
+      <a href="BookCategory.html" aria-current="page" data-i18n="nav.categories">Категории</a>
+      <a href="book.html" data-i18n="nav.bookCatalog">Каталог</a>
     </nav>
   </header>
 
   <main class="category-shell">
     <section class="section">
       <div class="section__head">
-        <h2 class="section__title lang" data-lang="ru">Быстрая навигация по 69 направлениям</h2>
-        <h2 class="section__title lang" data-lang="en">Navigate 69 specialties</h2>
-        <h2 class="section__title lang" data-lang="tm">69 lukmançylyk ugry</h2>
-        <p class="section__subtitle lang" data-lang="ru">Используйте поисковую строку ниже — результаты обновляются мгновенно.</p>
-        <p class="section__subtitle lang" data-lang="en">Use the search box below — results update instantly.</p>
-        <p class="section__subtitle lang" data-lang="tm">Aşakdaky gözleg gutusyny ulanyň — netijeler bada-bat täzeleýär.</p>
+        <h2 class="section__title" data-i18n="category.leadTitle">Быстрая навигация по 69 направлениям</h2>
+        <p class="section__subtitle" data-i18n="category.leadSubtitle">Используйте поисковую строку ниже — результаты обновляются мгновенно.</p>
       </div>
       <div class="category-search">
         <label for="category-search">
-          <span class="lang" data-lang="ru">Поиск по категориям</span>
-          <span class="lang" data-lang="en">Search categories</span>
-          <span class="lang" data-lang="tm">Kategoriýalar boýunça gözleg</span>
+          <span data-i18n="category.searchLabel">Поиск по категориям</span>
         </label>
-        <input id="category-search" type="search" placeholder="Анатомия, Kardiologiýa..." autocomplete="off">
-        <p id="category-count" class="category-count">—</p>
+        <input id="category-search" type="search" placeholder="Анатомия, Kardiologiýa..." autocomplete="off" data-i18n-placeholder="category.searchPlaceholder">
+        <p id="category-count" class="category-count" data-i18n="category.countPlaceholder">—</p>
       </div>
       <div class="table-wrapper">
         <table class="category-table" aria-live="polite">
           <thead>
             <tr>
-              <th>RU</th>
-              <th>TM</th>
-              <th>Книг</th>
+              <th data-i18n="category.columnRu">RU</th>
+              <th data-i18n="category.columnTm">TM</th>
+              <th data-i18n="category.columnBooks">Книг</th>
             </tr>
           </thead>
           <tbody data-category-body>
             <tr>
-              <td colspan="3" style="text-align: center">Загружаем направления...</td>
+              <td colspan="3" style="text-align: center" data-i18n="category.loading">Загружаем направления...</td>
             </tr>
           </tbody>
         </table>
@@ -86,12 +72,12 @@
 
   <footer class="site-footer">
     <div>
-      <strong>© 2025 MedLibrary</strong>
-      <p>Медицинская электронная библиотека. Все права защищены.</p>
+      <strong data-i18n="footer.copyright">© 2025 MedLibrary</strong>
+      <p data-i18n="footer.fullTagline">Медицинская электронная библиотека. Все права защищены.</p>
     </div>
     <div class="site-footer__links">
-      <a href="index.html">Главная</a>
-      <a href="book.html">Каталог</a>
+      <a href="index.html" data-i18n="nav.home">Главная</a>
+      <a href="book.html" data-i18n="nav.bookCatalog">Каталог</a>
     </div>
   </footer>
 

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="tm" data-lang="tm">
+<html lang="ru" data-lang="ru">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -25,42 +25,37 @@
       <header class="site-header">
         <div class="container site-header__bar">
           <div class="site-header__brand">
-            <p class="eyebrow lang" data-lang="ru">медицинская библиотека</p>
-            <p class="eyebrow lang" data-lang="en">medical library</p>
-            <p class="eyebrow lang" data-lang="tm">lukmançylyk kitaphanasy</p>
-            <h1 class="site-header__title lang" data-lang="ru">MedLibrary</h1>
-            <h1 class="site-header__title lang" data-lang="en">MedLibrary</h1>
-            <h1 class="site-header__title lang" data-lang="tm">MedLibrary</h1>
+            <p class="eyebrow" data-i18n="header.tagline">медицинская библиотека</p>
+            <h1 class="site-header__title">MedLibrary</h1>
           </div>
           <div class="site-header__actions">
-            <select id="language-select" aria-label="Сменить язык">
-              <option value="tm">Türkmençe</option>
-              <option value="ru" selected>Русский</option>
-              <option value="en">English</option>
-            </select>
+            <nav class="lang-switch" aria-label="Выбор языка">
+              <button type="button" data-lang="tm">TM</button>
+              <button type="button" data-lang="ru">RU</button>
+              <button type="button" data-lang="en">EN</button>
+            </nav>
             <button
               id="install-button"
               class="button button--ghost"
               type="button"
               hidden
               data-install-trigger
+              data-i18n="header.install"
             >
-              <span class="lang" data-lang="ru">Скачать приложение</span>
-              <span class="lang" data-lang="en">Download app</span>
-              <span class="lang" data-lang="tm">Programmany ýükläň</span>
+              Скачать приложение
             </button>
           </div>
         </div>
         <nav class="site-nav" aria-label="Основная навигация">
           <div class="container site-nav__wrap">
-            <a href="#hero">Главная</a>
-            <a href="#features">Возможности</a>
-            <a href="#catalog">Каталог</a>
-            <a href="#platform">Платформа</a>
-            <a href="#gallery">Интерфейс</a>
-            <a href="#contact">Связь</a>
-            <a href="book.html">Каталог книг</a>
-            <a href="BookCategory.html">Категории</a>
+            <a href="#hero" data-i18n="nav.home">Главная</a>
+            <a href="#features" data-i18n="nav.features">Возможности</a>
+            <a href="#catalog" data-i18n="nav.catalog">Каталог</a>
+            <a href="#platform" data-i18n="nav.platform">Платформа</a>
+            <a href="#gallery" data-i18n="nav.gallery">Интерфейс</a>
+            <a href="#contact" data-i18n="nav.contact">Связь</a>
+            <a href="book.html" data-i18n="nav.bookCatalog">Каталог книг</a>
+            <a href="BookCategory.html" data-i18n="nav.categories">Категории</a>
           </div>
         </nav>
       </header>
@@ -69,80 +64,55 @@
         <section id="hero" class="hero">
           <div class="container hero__layout">
             <div class="hero__content">
-              <p class="hero__eyebrow lang" data-lang="ru">
+              <p class="hero__eyebrow" data-i18n="hero.eyebrow">
                 Современный сценарий
               </p>
-              <p class="hero__eyebrow lang" data-lang="en">Modern experience</p>
-              <p class="hero__eyebrow lang" data-lang="tm">
-                Täzeçillik tejribesi
-              </p>
-              <h2 class="hero__title lang" data-lang="ru">
+              <h2 class="hero__title" data-i18n="hero.title">
                 Каталог медицинских знаний
               </h2>
-              <h2 class="hero__title lang" data-lang="en">
-               Medical catalog
-              </h2>
-              <h2 class="hero__title lang" data-lang="tm">
-                Lukmançylyk katalogy
-              </h2>
-              <p class="hero__text lang" data-lang="ru">
+              <p class="hero__text" data-i18n="hero.text">
                 Поиск, категории, офлайн‑режим и установка PWA. Акценты и кнопки ведут
                 к основным действиям.
               </p>
-              <p class="hero__text lang" data-lang="en">
-                Search, curated
-                categories, offline mode, and a clear PWA install flow inspired
-                by BooksMed.
-              </p>
-              <p class="hero__text lang" data-lang="tm">
-               Gözleg, baý kategoriýalar,
-                oflaýn režimi we düşnükli PWA gurnama. BooksMed logikasyna
-                meňzeş arassa gurluş.
-              </p>
               <div class="hero__actions">
-                <a class="button button--primary" href="book.html">
-                  <span class="lang" data-lang="ru">Открыть каталог</span>
-                  <span class="lang" data-lang="en">Open catalog</span>
-                  <span class="lang" data-lang="tm">Katalogy aç</span>
+                <a class="button button--primary" href="book.html" data-i18n="hero.ctaCatalog">
+                  Открыть каталог
                 </a>
-                <a class="button button--ghost" href="#platform">
-                  <span class="lang" data-lang="ru">Как устроено</span>
-                  <span class="lang" data-lang="en">How it works</span>
-                  <span class="lang" data-lang="tm">Näme üçin amatly</span>
+                <a class="button button--ghost" href="#platform" data-i18n="hero.ctaPlatform">
+                  Как устроено
                 </a>
                 <button
                   class="button button--text"
                   type="button"
                   data-install-trigger
                   data-install-sticky
+                  data-i18n="hero.ctaInstall"
                 >
-                  <span class="lang" data-lang="ru">Установить PWA</span>
-                  <span class="lang" data-lang="en">Install PWA</span>
-                  <span class="lang" data-lang="tm">PWA gurnamak</span>
+                  Установить PWA
                 </button>
               </div>
               <div class="hero__meta">
-                <span class="pill">1000+ книг </span>
-                <span class="pill">62 направлений</span>
-                <span class="pill">Онлайн и офлайн доступ</span>
+                <span class="pill" data-i18n="hero.metaBooks">1000+ книг</span>
+                <span class="pill" data-i18n="hero.metaDirections">62 направлений</span>
+                <span class="pill" data-i18n="hero.metaAccess">Онлайн и офлайн доступ</span>
               </div>
             </div>
             <div class="hero__panel" aria-hidden="true">
               <div class="preview-card">
                 <div class="preview-card__header">
-                  <span class="pill">Быстрый доступ</span>
+                  <span class="pill" data-i18n="preview.badge">Быстрый доступ</span>
                                  </div>
-                <p class="preview-card__title">
+                <p class="preview-card__title" data-i18n="preview.title">
                   Каталог, категории и поиск в одном экране
                 </p>
-                <p class="preview-card__text">
+                <p class="preview-card__text" data-i18n="preview.text">
                   Чистые карточки, быстрый доступ.
                 </p>
                 <div class="preview-card__actions">
-                  <a class="button button--ghost" href="BookCategory.html"
+                  <a class="button button--ghost" href="BookCategory.html" data-i18n="preview.ctaCategories"
                     >Категории</a
                   >
-                  <a class="button button--text" href="book.html#table"
+                  <a class="button button--text" href="book.html#table" data-i18n="preview.ctaFilters"
                     >Фильтры каталога</a
                   >
                 </div>
@@ -165,37 +135,37 @@
         >
           <div>
             <div class="section__head">
-      
-              <p class="section__subtitle">
+
+              <p class="section__subtitle" data-i18n="audit.subtitle">
                 Фокус на поиске, чтении и установке PWA. Новости, баннеры и
                 второстепенные блоки скрыты, чтобы не мешать работе.
               </p>
             </div>
             <ul class="checklist">
-              <li>Минимальная навигация: каталог, категории, авторизация</li>
-              <li>
+              <li data-i18n="audit.pointNavigation">Минимальная навигация: каталог, категории, авторизация</li>
+              <li data-i18n="audit.pointCta">
                 Четкие CTA — открыть каталог, скачать JSON/Excel, установить PWA
               </li>
-              <li>Подсказки по горячим клавишам только там, где они полезны</li>
-              <li>Плотные карточки с ключевыми метаданными книги</li>
+              <li data-i18n="audit.pointHotkeys">Подсказки по горячим клавишам только там, где они полезны</li>
+              <li data-i18n="audit.pointCards">Плотные карточки с ключевыми метаданными книги</li>
             </ul>
           </div>
           <div class="info-hygiene__panel">
-            <p class="info-hygiene__eyebrow">Новые опорные точки</p>
-            <h3 class="info-hygiene__title">Быстрые переходы</h3>
+            <p class="info-hygiene__eyebrow" data-i18n="audit.panelEyebrow">Новые опорные точки</p>
+            <h3 class="info-hygiene__title" data-i18n="audit.panelTitle">Быстрые переходы</h3>
             <div class="pill-row">
-              <a class="pill pill--ghost" href="book.html">Таблица каталога</a>
-              <a class="pill pill--ghost" href="BookCategory.html"
+              <a class="pill pill--ghost" href="book.html" data-i18n="audit.jumpTable">Таблица каталога</a>
+              <a class="pill pill--ghost" href="BookCategory.html" data-i18n="audit.jumpDirections"
                 >62 направлений</a
               >
-              <a class="pill pill--ghost" href="Book.xlsx" download
+              <a class="pill pill--ghost" href="Book.xlsx" download data-i18n="audit.jumpExcel"
                 >Экспорт Excel</a
               >
-              <a class="pill pill--ghost" href="data/books.json" download
+              <a class="pill pill--ghost" href="data/books.json" download data-i18n="audit.jumpJson"
                 >JSON для интеграций</a
               >
             </div>
-            <p class="info-hygiene__note">
+            <p class="info-hygiene__note" data-i18n="audit.note">
               Весь лишний контент убран в пользу быстрых сценариев поиска и
               скачивания.
             </p>
@@ -204,41 +174,41 @@
 
         <section id="features" class="section container">
           <div class="section__head">
-            <p class="eyebrow">Возможности</p>
-            <h2 class="section__title">Главные</h2>
-            <p class="section__subtitle">
+            <p class="eyebrow" data-i18n="features.eyebrow">Возможности</p>
+            <h2 class="section__title" data-i18n="features.title">Главные</h2>
+            <p class="section__subtitle" data-i18n="features.subtitle">
               Только то, что помогает найти, открыть или сохранить книгу.
             </p>
           </div>
           <div class="feature-grid">
             <article class="feature-card">
               <div class="feature-icon" aria-hidden="true">📚</div>
-              <h3>Единый каталог</h3>
-              <p>
+              <h3 data-i18n="features.catalog.title">Единый каталог</h3>
+              <p data-i18n="features.catalog.text">
                 Таблица с 1000+ книгами, быстрыми фильтрами и карточками — без
                 новостных блоков и отвлекающих панелей.
               </p>
             </article>
             <article class="feature-card">
               <div class="feature-icon" aria-hidden="true">🧭</div>
-              <h3>Категории BooksMed</h3>
-              <p>
+              <h3 data-i18n="features.categories.title">Категории BooksMed</h3>
+              <p data-i18n="features.categories.text">
                 69 направлений в привычной логике. Один клик — и сразу к нужной
                 области знаний.
               </p>
             </article>
             <article class="feature-card">
               <div class="feature-icon" aria-hidden="true">🔍</div>
-              <h3>Поиск без шумов</h3>
-              <p>
+              <h3 data-i18n="features.search.title">Поиск без шумов</h3>
+              <p data-i18n="features.search.text">
                 Глобальный поиск по всем колонкам с нормализацией текста.
                 Минимум отвлекающих элементов и вспомогательных окон.
               </p>
             </article>
             <article class="feature-card">
               <div class="feature-icon" aria-hidden="true">⚡</div>
-              <h3>Быстрый старт</h3>
-              <p>
+              <h3 data-i18n="features.start.title">Быстрый старт</h3>
+              <p data-i18n="features.start.text">
                 Готовые кнопки: каталог, категории, Excel/JSON и PWA — никакой
                 лишней навигации.
               </p>
@@ -249,41 +219,41 @@
         <section id="catalog" class="section section--split container">
           <div>
             <div class="section__head">
-              <p class="eyebrow">Каталог</p>
-              <h2 class="section__title">Таблица, карточки и экспорт</h2>
-              <p class="section__subtitle">
+              <p class="eyebrow" data-i18n="catalog.eyebrow">Каталог</p>
+              <h2 class="section__title" data-i18n="catalog.title">Таблица, карточки и экспорт</h2>
+              <p class="section__subtitle" data-i18n="catalog.subtitle">
                 Бережно обновленная структура: сортировки, фильтры по колонкам и
                 чистые карточки.
               </p>
             </div>
             <ul class="checklist">
-              <li>Поиск по названию, авторам, ISBN, УДК, ББК</li>
-              <li>Карточки найденных книг без перегруза информации</li>
-              <li>Экспорт в Excel/JSON и офлайн-доступ</li>
+              <li data-i18n="catalog.pointSearch">Поиск по названию, авторам, ISBN, УДК, ББК</li>
+              <li data-i18n="catalog.pointCards">Карточки найденных книг без перегруза информации</li>
+              <li data-i18n="catalog.pointExport">Экспорт в Excel/JSON и офлайн-доступ</li>
             </ul>
             <div class="cta-inline">
-              <a class="button button--primary" href="book.html"
+              <a class="button button--primary" href="book.html" data-i18n="catalog.ctaCatalog"
                 >Каталог книг</a
               >
-              <a class="button button--ghost" href="Book.xlsx" download
+              <a class="button button--ghost" href="Book.xlsx" download data-i18n="catalog.ctaExcel"
                 >Excel</a
               >
-              <a class="button button--text" href="data/books.json" download
+              <a class="button button--text" href="data/books.json" download data-i18n="catalog.ctaJson"
                 >JSON</a
               >
             </div>
           </div>
           <div class="accent-card">
-            <p class="accent-card__eyebrow">Подборка за секунды</p>
-            <h3 class="accent-card__title">Готовые маршруты</h3>
+            <p class="accent-card__eyebrow" data-i18n="catalog.accentEyebrow">Подборка за секунды</p>
+            <h3 class="accent-card__title" data-i18n="catalog.accentTitle">Готовые маршруты</h3>
             <div class="accent-card__tags">
-              <span class="pill">Кардиология</span>
-              <span class="pill">Педиатрия</span>
-              <span class="pill">Хирургия</span>
-              <span class="pill">Анатомия</span>
-              <span class="pill">Диагностика</span>
+              <span class="pill" data-i18n="catalog.tagCardiology">Кардиология</span>
+              <span class="pill" data-i18n="catalog.tagPediatrics">Педиатрия</span>
+              <span class="pill" data-i18n="catalog.tagSurgery">Хирургия</span>
+              <span class="pill" data-i18n="catalog.tagAnatomy">Анатомия</span>
+              <span class="pill" data-i18n="catalog.tagDiagnostics">Диагностика</span>
             </div>
-            <p class="accent-card__text">
+            <p class="accent-card__text" data-i18n="catalog.accentText">
               Категории и фильтры открываются в соседних вкладках, чтобы быстрее
               найти нужный материал.
             </p>
@@ -292,17 +262,17 @@
 
         <section id="platform" class="section container">
           <div class="section__head">
-            <p class="eyebrow">Платформа</p>
-            <h2 class="section__title">Современная логика без лишнего шума</h2>
-            <p class="section__subtitle">
+            <p class="eyebrow" data-i18n="platform.eyebrow">Платформа</p>
+            <h2 class="section__title" data-i18n="platform.title">Современная логика без лишнего шума</h2>
+            <p class="section__subtitle" data-i18n="platform.subtitle">
               Легкий интерфейс, PWA, офлайн-режим и плавные сценарии
               авторизации.
             </p>
           </div>
           <div class="platform__grid">
             <article class="platform__card">
-              <h3>PWA и офлайн</h3>
-              <p>
+              <h3 data-i18n="platform.pwa.title">PWA и офлайн</h3>
+              <p data-i18n="platform.pwa.text">
                 Сервис-воркер кэширует каталог, поэтому поиск и чтение
                 продолжаются даже без сети.
               </p>
@@ -311,24 +281,25 @@
                 type="button"
                 data-install-trigger
                 data-install-sticky
+                data-i18n="platform.pwa.cta"
               >
                 Установить
               </button>
             </article>
             <article class="platform__card">
-              <h3>Авторизация</h3>
-              <p>
+              <h3 data-i18n="platform.auth.title">Авторизация</h3>
+              <p data-i18n="platform.auth.text">
                 Регистрация, вход, Google Identity и понятные статусы. Нет
                 лишних форм — только essentials.
               </p>
             </article>
             <article class="platform__card">
-              <h3>Структура BooksMed</h3>
-              <p>
+              <h3 data-i18n="platform.structure.title">Структура BooksMed</h3>
+              <p data-i18n="platform.structure.text">
                 Навигация, категории и фильтры повторяют логику BooksMed, но с
                 более чистым визуалом.
               </p>
-              <a class="button button--text" href="BookCategory.html"
+              <a class="button button--text" href="BookCategory.html" data-i18n="platform.structure.cta"
                 >Перейти к категориям</a
               >
             </article>
@@ -337,9 +308,9 @@
 
         <section id="gallery" class="gallery-slider section container">
           <div class="section__head">
-            <p class="eyebrow">Интерфейс</p>
-            <h2>Как выглядит обновление</h2>
-            <p class="section__subtitle">
+            <p class="eyebrow" data-i18n="gallery.eyebrow">Интерфейс</p>
+            <h2 data-i18n="gallery.title">Как выглядит обновление</h2>
+            <p class="section__subtitle" data-i18n="gallery.subtitle">
               Светлые карточки, четкие акценты и быстрые кнопки.
             </p>
           </div>
@@ -411,41 +382,25 @@
 
         <section id="contact" class="contact section container">
           <div class="section__head">
-            <p class="eyebrow lang" data-lang="ru">Связь</p>
-            <p class="eyebrow lang" data-lang="en">Contact</p>
-            <p class="eyebrow lang" data-lang="tm">Habarlaşyň</p>
-            <h2 class="section__title lang" data-lang="ru">
+            <p class="eyebrow" data-i18n="contact.eyebrow">Связь</p>
+            <h2 class="section__title" data-i18n="contact.title">
               Напишите разработчику
             </h2>
-            <h2 class="section__title lang" data-lang="en">Get in touch</h2>
-            <h2 class="section__title lang" data-lang="tm">Habarlaşyň</h2>
-            <p class="section__subtitle lang" data-lang="ru">
+            <p class="section__subtitle" data-i18n="contact.subtitle">
               Предложите книги, интеграции или улучшения интерфейса.
-            </p>
-            <p class="section__subtitle lang" data-lang="en">
-              Share books to add, integrations, or UX ideas.
-            </p>
-            <p class="section__subtitle lang" data-lang="tm">
-              Goşmaly kitaplary, integrasiýalary ýa-da UX teklipleriňizi iberiň.
             </p>
           </div>
           <form class="contact__form" onsubmit="sendMail(); return false;">
             <label class="form-group">
-              <span class="lang" data-lang="ru">Ваше имя</span>
-              <span class="lang" data-lang="en">Name</span>
-              <span class="lang" data-lang="tm">Adyňyz</span>
+              <span data-i18n="contact.name">Ваше имя</span>
               <input type="text" id="name" name="name" required />
             </label>
             <label class="form-group">
-              <span class="lang" data-lang="ru">Ваш email</span>
-              <span class="lang" data-lang="en">Email</span>
-              <span class="lang" data-lang="tm">Email</span>
+              <span data-i18n="contact.email">Ваш email</span>
               <input type="email" id="email" name="email" required />
             </label>
             <label class="form-group">
-              <span class="lang" data-lang="ru">Сообщение</span>
-              <span class="lang" data-lang="en">Message</span>
-              <span class="lang" data-lang="tm">Habar</span>
+              <span data-i18n="contact.message">Сообщение</span>
               <textarea id="message" name="message" required></textarea>
             </label>
             <button
@@ -453,10 +408,8 @@
               type="submit"
               accesskey="s"
               aria-describedby="contact-hotkey"
+              data-i18n="contact.submit"
             >
-              <span class="lang" data-lang="ru">Отправить</span>
-              <span class="lang" data-lang="en">Send</span>
-              <span class="lang" data-lang="tm">Ugrat</span>
               <span id="contact-hotkey" class="hotkey-hint" aria-hidden="true"
                 >Alt+Shift+S</span
               >
@@ -478,13 +431,13 @@
       <footer class="site-footer">
         <div class="container site-footer__content">
           <div>
-            <strong>© 2025 MedLibrary</strong>
-            <p>Медицинская электронная библиотека.</p>
+            <strong data-i18n="footer.copyright">© 2025 MedLibrary</strong>
+            <p data-i18n="footer.tagline">Медицинская электронная библиотека.</p>
           </div>
           <div class="site-footer__links">
-            <a href="index.html">Главная</a>
-            <a href="BookCategory.html">Категории</a>
-            <a href="book.html">Каталог</a>
+            <a href="index.html" data-i18n="nav.home">Главная</a>
+            <a href="BookCategory.html" data-i18n="nav.categories">Категории</a>
+            <a href="book.html" data-i18n="nav.bookCatalog">Каталог</a>
           </div>
         </div>
       </footer>

--- a/scripts.js
+++ b/scripts.js
@@ -1,6 +1,7 @@
 const TOKEN_KEY = "medlibraryToken";
 const LOCAL_USERS_KEY = "medlibraryLocalUsers";
 const LOCAL_SESSION_KEY = "medlibraryLocalSession";
+const LANG_STORAGE_KEY = "preferredLanguage";
 const BOOK_TABLE_COLUMNS = [
   "Название книги",
   "Имя автора",
@@ -93,6 +94,230 @@ const UI_TEXTS = {
     tm: "Sahypalar",
   },
 };
+
+const PAGE_TRANSLATIONS = {
+  "header.tagline": {
+    ru: "медицинская библиотека",
+    en: "medical library",
+    tm: "lukmançylyk kitaphanasy",
+  },
+  "header.install": {
+    ru: "Скачать приложение",
+    en: "Download app",
+    tm: "Programmany ýükläň",
+  },
+  "nav.home": { ru: "Главная", en: "Home", tm: "Baş sahypa" },
+  "nav.features": { ru: "Возможности", en: "Features", tm: "Mümkinçilikler" },
+  "nav.catalog": { ru: "Каталог", en: "Catalog", tm: "Katalog" },
+  "nav.platform": { ru: "Платформа", en: "Platform", tm: "Platforma" },
+  "nav.gallery": { ru: "Интерфейс", en: "Interface", tm: "Interfeys" },
+  "nav.contact": { ru: "Связь", en: "Contact", tm: "Habarlaşyň" },
+  "nav.bookCatalog": { ru: "Каталог книг", en: "Book catalog", tm: "Kitap katalogy" },
+  "nav.categories": { ru: "Категории", en: "Categories", tm: "Kategoriýalar" },
+  "hero.eyebrow": { ru: "Современный сценарий", en: "Modern experience", tm: "Täzeçillik tejribesi" },
+  "hero.title": { ru: "Каталог медицинских знаний", en: "Medical knowledge catalog", tm: "Lukmançylyk katalogy" },
+  "hero.text": {
+    ru: "Поиск, категории, офлайн‑режим и установка PWA. Акценты и кнопки ведут к основным действиям.",
+    en: "Search, curated categories, offline mode, and a clear PWA install flow focused on primary actions.",
+    tm: "Gözleg, baý kategoriýalar, oflaýn režimi we esasy hereketlere gönükdirilen düşnükli PWA gurnama.",
+  },
+  "hero.ctaCatalog": { ru: "Открыть каталог", en: "Open catalog", tm: "Katalogy aç" },
+  "hero.ctaPlatform": { ru: "Как устроено", en: "How it works", tm: "Näme üçin amatly" },
+  "hero.ctaInstall": { ru: "Установить PWA", en: "Install PWA", tm: "PWA gurnamak" },
+  "hero.metaBooks": { ru: "1000+ книг", en: "1000+ books", tm: "1000+ kitap" },
+  "hero.metaDirections": { ru: "62 направлений", en: "62 specialties", tm: "62 ugur" },
+  "hero.metaAccess": { ru: "Онлайн и офлайн доступ", en: "Online and offline access", tm: "Onlaýn we oflaýn elýeterlilik" },
+  "preview.badge": { ru: "Быстрый доступ", en: "Quick access", tm: "Çalt giriş" },
+  "preview.title": {
+    ru: "Каталог, категории и поиск в одном экране",
+    en: "Catalog, categories, and search on one screen",
+    tm: "Katalog, kategoriýalar we gözleg bir ekranda",
+  },
+  "preview.text": {
+    ru: "Чистые карточки, быстрый доступ.",
+    en: "Clean cards and instant access.",
+    tm: "Arassa kartlar, çalt giriş.",
+  },
+  "preview.ctaCategories": { ru: "Категории", en: "Categories", tm: "Kategoriýalar" },
+  "preview.ctaFilters": { ru: "Фильтры каталога", en: "Catalog filters", tm: "Katalog filtrleri" },
+  "audit.subtitle": {
+    ru: "Фокус на поиске, чтении и установке PWA. Новости, баннеры и второстепенные блоки скрыты, чтобы не мешать работе.",
+    en: "Focus on search, reading, and installing the PWA. News and secondary blocks stay out of the way.",
+    tm: "Gözleg, okamak we PWA gurnama öň planda. Täzelikler we başga bloklar päsgel bermeýär.",
+  },
+  "audit.pointNavigation": {
+    ru: "Минимальная навигация: каталог, категории, авторизация",
+    en: "Minimal navigation: catalog, categories, sign-in",
+    tm: "Minimal nawigasiýa: katalog, kategoriýalar, hasaba giriş",
+  },
+  "audit.pointCta": {
+    ru: "Четкие CTA — открыть каталог, скачать JSON/Excel, установить PWA",
+    en: "Clear CTAs — open the catalog, download JSON/Excel, install the PWA",
+    tm: "Düşnükli düwmeler — katalogy açmak, JSON/Excel ýüklemek, PWA gurmak",
+  },
+  "audit.pointHotkeys": {
+    ru: "Подсказки по горячим клавишам только там, где они полезны",
+    en: "Hotkey hints only where they help",
+    tm: "Gyssagly klawiş görkezmeleri diňe peýdaly ýerlerinde",
+  },
+  "audit.pointCards": {
+    ru: "Плотные карточки с ключевыми метаданными книги",
+    en: "Compact cards with key book metadata",
+    tm: "Kitabyň möhüm metadatalary bilen gysga kartlar",
+  },
+  "audit.panelEyebrow": { ru: "Новые опорные точки", en: "New anchors", tm: "Täze baglanyşyklar" },
+  "audit.panelTitle": { ru: "Быстрые переходы", en: "Quick jumps", tm: "Çalt geçişler" },
+  "audit.jumpTable": { ru: "Таблица каталога", en: "Catalog table", tm: "Katalog tablisası" },
+  "audit.jumpDirections": { ru: "62 направлений", en: "62 specialties", tm: "62 ugur" },
+  "audit.jumpExcel": { ru: "Экспорт Excel", en: "Excel export", tm: "Excel eksporty" },
+  "audit.jumpJson": { ru: "JSON для интеграций", en: "JSON for integrations", tm: "Integrasiýalar üçin JSON" },
+  "audit.note": {
+    ru: "Весь лишний контент убран в пользу быстрых сценариев поиска и скачивания.",
+    en: "All extra content is removed in favor of quick search and download flows.",
+    tm: "Gözleg we ýükleme üçin tiz ssenariler peýdasyna goşmaça mazmun aýryldy.",
+  },
+  "features.eyebrow": { ru: "Возможности", en: "Features", tm: "Mümkinçilikler" },
+  "features.title": { ru: "Главные", en: "Core", tm: "Esasy" },
+  "features.subtitle": {
+    ru: "Только то, что помогает найти, открыть или сохранить книгу.",
+    en: "Only what helps you find, open, or save a book.",
+    tm: "Kitaby tapmaga, açmaga ýa-da saklamaga kömek edýän zatlar.",
+  },
+  "features.catalog.title": { ru: "Единый каталог", en: "Unified catalog", tm: "Biri-bir katalog" },
+  "features.catalog.text": {
+    ru: "Таблица с 1000+ книгами, быстрыми фильтрами и карточками — без новостных блоков и отвлекающих панелей.",
+    en: "Table with 1000+ books, fast filters, and cards — no news blocks or distractions.",
+    tm: "1000+ kitaply tablisa, çalt filtrler we kartlar — habar bloklary we üns üjeýleri ýok.",
+  },
+  "features.categories.title": { ru: "Категории BooksMed", en: "BooksMed categories", tm: "BooksMed kategoriýalary" },
+  "features.categories.text": {
+    ru: "69 направлений в привычной логике. Один клик — и сразу к нужной области знаний.",
+    en: "69 specialties in a familiar logic. One click takes you to the right field.",
+    tm: "69 ugur öwrenişi — tanyş logika. Bir basyş bilen gerek ugry tapyň.",
+  },
+  "features.search.title": { ru: "Поиск без шумов", en: "Noise-free search", tm: "Şowunsyz gözleg" },
+  "features.search.text": {
+    ru: "Глобальный поиск по всем колонкам с нормализацией текста. Минимум отвлекающих элементов и вспомогательных окон.",
+    en: "Global search across all columns with normalized text. Minimal distractions and popups.",
+    tm: "Ähli sütünlerde adatylaşdyrylan global gözleg. Üns çekiji elementler minimum derejede.",
+  },
+  "features.start.title": { ru: "Быстрый старт", en: "Quick start", tm: "Tiz başlangyç" },
+  "features.start.text": {
+    ru: "Готовые кнопки: каталог, категории, Excel/JSON и PWA — никакой лишней навигации.",
+    en: "Ready shortcuts: catalog, categories, Excel/JSON, and PWA — no extra navigation.",
+    tm: "Taýýar düwmeler: katalog, kategoriýalar, Excel/JSON we PWA — goşmaça nawigasiýa ýok.",
+  },
+  "catalog.eyebrow": { ru: "Каталог", en: "Catalog", tm: "Katalog" },
+  "catalog.title": { ru: "Таблица, карточки и экспорт", en: "Table, cards, and export", tm: "Tablisa, kartlar we eksport" },
+  "catalog.subtitle": {
+    ru: "Бережно обновленная структура: сортировки, фильтры по колонкам и чистые карточки.",
+    en: "Carefully refreshed structure: sorting, column filters, and clean cards.",
+    tm: "Üns bilen täzelenen gurluş: tertiplemeler, sütün filtrleri we arassa kartlar.",
+  },
+  "catalog.pointSearch": {
+    ru: "Поиск по названию, авторам, ISBN, УДК, ББК",
+    en: "Search by title, authors, ISBN, UDC, BBK",
+    tm: "Ady, awtorlary, ISBN, UDK, BBK boýunça gözleg",
+  },
+  "catalog.pointCards": {
+    ru: "Карточки найденных книг без перегруза информации",
+    en: "Book cards without information overload",
+    tm: "Maglumat artykmaçsyz kitap kartlary",
+  },
+  "catalog.pointExport": {
+    ru: "Экспорт в Excel/JSON и офлайн-доступ",
+    en: "Export to Excel/JSON and offline access",
+    tm: "Excel/JSON eksporty we oflaýn elýeterlilik",
+  },
+  "catalog.ctaCatalog": { ru: "Каталог книг", en: "Book catalog", tm: "Kitap katalogy" },
+  "catalog.ctaExcel": { ru: "Excel", en: "Excel", tm: "Excel" },
+  "catalog.ctaJson": { ru: "JSON", en: "JSON", tm: "JSON" },
+  "catalog.accentEyebrow": { ru: "Подборка за секунды", en: "Picks in seconds", tm: "Sekuntda saýlama" },
+  "catalog.accentTitle": { ru: "Готовые маршруты", en: "Ready routes", tm: "Taýýar ugrukdyryşlar" },
+  "catalog.tagCardiology": { ru: "Кардиология", en: "Cardiology", tm: "Kardiologiýa" },
+  "catalog.tagPediatrics": { ru: "Педиатрия", en: "Pediatrics", tm: "Pediatriýa" },
+  "catalog.tagSurgery": { ru: "Хирургия", en: "Surgery", tm: "Hirurgiýa" },
+  "catalog.tagAnatomy": { ru: "Анатомия", en: "Anatomy", tm: "Anatomiýa" },
+  "catalog.tagDiagnostics": { ru: "Диагностика", en: "Diagnostics", tm: "Diagnostika" },
+  "catalog.accentText": {
+    ru: "Категории и фильтры открываются в соседних вкладках, чтобы быстрее найти нужный материал.",
+    en: "Categories and filters open in nearby tabs so you can find material faster.",
+    tm: "Kategoriýalar we filtrler goňşy goýmalarda açylýar, şonuň üçin maglumatlary çalt tapyň.",
+  },
+  "platform.eyebrow": { ru: "Платформа", en: "Platform", tm: "Platforma" },
+  "platform.title": { ru: "Современная логика без лишнего шума", en: "Modern logic without noise", tm: "Şowsuz häzirki zaman logikasy" },
+  "platform.subtitle": {
+    ru: "Легкий интерфейс, PWA, офлайн-режим и плавные сценарии авторизации.",
+    en: "Lightweight UI, PWA, offline mode, and smooth auth flows.",
+    tm: "Ýeňil interfeýs, PWA, oflaýn režim we ýumşak awtorizasiýa ssenarileri.",
+  },
+  "platform.pwa.title": { ru: "PWA и офлайн", en: "PWA and offline", tm: "PWA we oflaýn" },
+  "platform.pwa.text": {
+    ru: "Сервис-воркер кэширует каталог, поэтому поиск и чтение продолжаются даже без сети.",
+    en: "The service worker caches the catalog so search and reading continue offline.",
+    tm: "Hyzmatçy işçisi katalogy keşleýär, şonuň üçin gözleg we okamak tor ýok wagty hem dowam edýär.",
+  },
+  "platform.pwa.cta": { ru: "Установить", en: "Install", tm: "Gurmak" },
+  "platform.auth.title": { ru: "Авторизация", en: "Authentication", tm: "Awtentifikasiýa" },
+  "platform.auth.text": {
+    ru: "Регистрация, вход, Google Identity и понятные статусы. Нет лишних форм — только essentials.",
+    en: "Sign-up, login, Google Identity, and clear states. No extra forms — only essentials.",
+    tm: "Hasaba alyş, giriş, Google Identity we düşnükli statuslar. Goşmaça blankalar ýok — diňe zerur zatlar.",
+  },
+  "platform.structure.title": { ru: "Структура BooksMed", en: "BooksMed structure", tm: "BooksMed gurluşy" },
+  "platform.structure.text": {
+    ru: "Навигация, категории и фильтры повторяют логику BooksMed, но с более чистым визуалом.",
+    en: "Navigation, categories, and filters mirror BooksMed logic with a cleaner look.",
+    tm: "Nawigasiýa, kategoriýalar we filtrler BooksMed logikasyna meňzeýär, has arassa görnüş bilen.",
+  },
+  "platform.structure.cta": { ru: "Перейти к категориям", en: "Go to categories", tm: "Kategoriýalara geç" },
+  "gallery.eyebrow": { ru: "Интерфейс", en: "Interface", tm: "Interfeys" },
+  "gallery.title": { ru: "Как выглядит обновление", en: "How the update looks", tm: "Täzelenme nähili görünýär" },
+  "gallery.subtitle": {
+    ru: "Светлые карточки, четкие акценты и быстрые кнопки.",
+    en: "Bright cards, clear accents, and quick actions.",
+    tm: "Ýagty kartlar, anyk aýratynlyklar we çalt hereketler.",
+  },
+  "contact.eyebrow": { ru: "Связь", en: "Contact", tm: "Habarlaşyň" },
+  "contact.title": { ru: "Напишите разработчику", en: "Message the developer", tm: "Programmist bilen habarlaşyň" },
+  "contact.subtitle": {
+    ru: "Предложите книги, интеграции или улучшения интерфейса.",
+    en: "Suggest books, integrations, or UX improvements.",
+    tm: "Kitaplar, integrasiýalar ýa-da UX gowulaşmalaryny teklip ediň.",
+  },
+  "contact.name": { ru: "Ваше имя", en: "Your name", tm: "Adyňyz" },
+  "contact.email": { ru: "Ваш email", en: "Email", tm: "Email" },
+  "contact.message": { ru: "Сообщение", en: "Message", tm: "Habar" },
+  "contact.submit": { ru: "Отправить", en: "Send", tm: "Ugrat" },
+  "footer.copyright": { ru: "© 2025 MedLibrary", en: "© 2025 MedLibrary", tm: "© 2025 MedLibrary" },
+  "footer.tagline": {
+    ru: "Медицинская электронная библиотека.",
+    en: "Medical digital library.",
+    tm: "Sanly lukmançylyk kitaphanasy.",
+  },
+  "footer.fullTagline": {
+    ru: "Медицинская электронная библиотека. Все права защищены.",
+    en: "Medical digital library. All rights reserved.",
+    tm: "Sanly lukmançylyk kitaphanasy. Ähli hukuklar goralandyr.",
+  },
+  "category.tagline": { ru: "Категории библиотеки", en: "Library categories", tm: "Kategoriýalar" },
+  "category.title": { ru: "Медицинские направления", en: "Medical specialties", tm: "Lukmançylyk ugurlary" },
+  "category.leadTitle": { ru: "Быстрая навигация по 69 направлениям", en: "Navigate 69 specialties", tm: "69 lukmançylyk ugryna çalt geçiş" },
+  "category.leadSubtitle": {
+    ru: "Используйте поисковую строку ниже — результаты обновляются мгновенно.",
+    en: "Use the search box below — results update instantly.",
+    tm: "Aşakdaky gözleg gutusyny ulanyň — netijeler bada-bat täzelenýär.",
+  },
+  "category.searchLabel": { ru: "Поиск по категориям", en: "Search categories", tm: "Kategoriýalar boýunça gözleg" },
+  "category.searchPlaceholder": { ru: "Анатомия, Kardiologiýa...", en: "Anatomy, Cardiology...", tm: "Anatomiýa, Kardiologiýa..." },
+  "category.countPlaceholder": { ru: "—", en: "—", tm: "—" },
+  "category.columnRu": { ru: "RU", en: "RU", tm: "RU" },
+  "category.columnTm": { ru: "TM", en: "TM", tm: "TM" },
+  "category.columnBooks": { ru: "Книг", en: "Books", tm: "Kitap" },
+  "category.loading": { ru: "Загружаем направления...", en: "Loading specialties...", tm: "Ugurlar ýüklenýär..." },
+};
+
+const I18N_STRINGS = { ...UI_TEXTS, ...PAGE_TRANSLATIONS };
 
 const CATEGORY_FALLBACK = [
   { ru: "Акушерство и Гинекология", tm: "Akuşerçilik we Ginekologiýa" },
@@ -258,43 +483,87 @@ function initAuthModal() {
   return { open: openModal, close: closeModal };
 }
 
-function initLanguageSwitcher() {
-  const languageSelect = document.getElementById("language-select");
-  if (!languageSelect) {
-    return;
-  }
+function applyDocumentLanguage(lang) {
+  document.documentElement.dataset.lang = lang;
+  document.documentElement.lang = lang;
 
-  const documentLang = document.documentElement.dataset.lang || document.documentElement.lang;
-  if (documentLang && languageSelect.value !== documentLang) {
-    const optionExists = Array.from(languageSelect.options).some((option) => option.value === documentLang);
-    if (optionExists) {
-      languageSelect.value = documentLang;
+  document.querySelectorAll("[data-i18n]").forEach((element) => {
+    const key = element.dataset.i18n;
+    if (!key) {
+      return;
     }
-  }
 
-  const changeLanguage = () => {
-    const lang = languageSelect.value || documentLang || "tm";
-    document.documentElement.dataset.lang = lang;
-    document.documentElement.lang = lang;
-    document.querySelectorAll(".lang").forEach((element) => {
-      const isVisible = element.getAttribute("data-lang") === lang;
-      element.hidden = !isVisible;
-      element.setAttribute("aria-hidden", isVisible ? "false" : "true");
-      if (isVisible) {
-        element.style.removeProperty("display");
+    let args = {};
+    if (element.dataset.i18nArgs) {
+      try {
+        args = JSON.parse(element.dataset.i18nArgs);
+      } catch (error) {
+        console.error("Failed to parse translation arguments", error);
       }
-    });
-    updatePlaceholders(lang);
-    document
-      .querySelectorAll("[data-i18n-key]")
-      .forEach((element) => translateElement(element));
-    if (bookSearchState.isTableReady) {
-      applyBookFilters();
     }
+
+    if (I18N_STRINGS[key]) {
+      element.textContent = translate(key, args);
+    }
+  });
+
+  document.querySelectorAll("[data-i18n-placeholder]").forEach((input) => {
+    const key = input.dataset.i18nPlaceholder;
+    if (key && I18N_STRINGS[key]) {
+      input.placeholder = translate(key);
+    }
+  });
+
+  updatePlaceholders(lang);
+
+  if (bookSearchState.isTableReady) {
+    applyBookFilters();
+  }
+}
+
+function initLanguageSwitcher() {
+  const languageSwitcher = document.querySelector(".lang-switch");
+  const buttons = languageSwitcher?.querySelectorAll("[data-lang]");
+  const languageSelect = document.getElementById("language-select");
+  const savedLanguage = localStorage.getItem(LANG_STORAGE_KEY);
+  const fallbackLanguage = document.documentElement.dataset.lang || document.documentElement.lang || "ru";
+  const initialLanguage = savedLanguage || fallbackLanguage;
+
+  const setActiveButton = (lang) => {
+    buttons?.forEach((button) => {
+      const isActive = button.dataset.lang === lang;
+      button.classList.toggle("is-active", isActive);
+      button.setAttribute("aria-pressed", isActive ? "true" : "false");
+    });
   };
 
-  languageSelect.addEventListener("change", changeLanguage);
-  changeLanguage();
+  const changeLanguage = (lang) => {
+    const targetLang = lang || fallbackLanguage;
+    setActiveButton(targetLang);
+    if (languageSelect && languageSelect.value !== targetLang) {
+      languageSelect.value = targetLang;
+    }
+    localStorage.setItem(LANG_STORAGE_KEY, targetLang);
+    applyDocumentLanguage(targetLang);
+  };
+
+  buttons?.forEach((button) => {
+    button.type = "button";
+    button.addEventListener("click", () => changeLanguage(button.dataset.lang));
+  });
+
+  if (languageSelect) {
+    languageSelect.addEventListener("change", (event) => {
+      changeLanguage(event.target.value);
+    });
+  }
+
+  if (languageSelect && languageSelect.value !== initialLanguage) {
+    languageSelect.value = initialLanguage;
+  }
+
+  applyDocumentLanguage(initialLanguage);
+  setActiveButton(initialLanguage);
 }
 
 function initGallerySlider() {
@@ -1296,7 +1565,7 @@ function updatePlaceholders(lang) {
 
 function translate(key, replacements = {}) {
   const lang = document.documentElement.dataset.lang || "ru";
-  const template = UI_TEXTS[key]?.[lang] || UI_TEXTS[key]?.ru || "";
+  const template = I18N_STRINGS[key]?.[lang] || I18N_STRINGS[key]?.ru || key;
   return Object.keys(replacements).reduce((acc, currentKey) => {
     return acc.replace(new RegExp(`{${currentKey}}`, "g"), replacements[currentKey]);
   }, template);

--- a/styles.css
+++ b/styles.css
@@ -135,6 +135,40 @@ main {
   border-color: rgba(26, 108, 255, 0.25);
 }
 
+.lang-switch {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding: 0.15rem;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--surface);
+}
+
+.lang-switch button {
+  border: none;
+  background: transparent;
+  color: var(--muted);
+  font-weight: 700;
+  padding: 0.45rem 0.9rem;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: background 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.lang-switch button:hover,
+.lang-switch button:focus-visible {
+  color: var(--text);
+  background: rgba(26, 108, 255, 0.08);
+  outline: none;
+}
+
+.lang-switch button.is-active {
+  color: #fff;
+  background: linear-gradient(120deg, var(--primary), var(--primary-2));
+  box-shadow: 0 8px 20px rgba(26, 108, 255, 0.2);
+}
+
 #language-select {
   border-radius: 12px;
   border: 1px solid var(--border);


### PR DESCRIPTION
## Summary
- replace duplicated multilingual markup on the landing and categories pages with data-i18n keys
- add a shared translation dictionary and language switching logic that persists the chosen locale
- style the new language toggle for consistent placement alongside existing controls

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923409970ec8329ab79fb6c0600aa0b)