### PR TITLE
Replace missing gallery assets with bundled SVG illustrations

### DIFF
--- a/public/gallery/slide-1.svg
+++ b/public/gallery/slide-1.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-label="Catalog preview">
+  <defs>
+    <linearGradient id="grad-1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0b1224" />
+      <stop offset="100%" stop-color="#1a2a4a" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#grad-1)" rx="32" />
+  <g fill="none" stroke="rgba(255,255,255,0.4)" stroke-width="8">
+    <rect x="120" y="160" width="1360" height="580" rx="28" />
+    <rect x="160" y="220" width="1280" height="420" rx="20" />
+    <line x1="160" y1="320" x2="1440" y2="320" />
+    <line x1="160" y1="420" x2="1440" y2="420" />
+  </g>
+  <text x="140" y="140" fill="rgba(255,255,255,0.85)" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="700">Catalog preview</text>
+  <text x="140" y="760" fill="rgba(255,255,255,0.7)" font-family="Inter, Arial, sans-serif" font-size="32">MedLibrary UI highlight #1</text>
+</svg>

--- a/public/gallery/slide-2.svg
+++ b/public/gallery/slide-2.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-label="Book table filters">
+  <defs>
+    <linearGradient id="grad-2" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#15304a" />
+      <stop offset="100%" stop-color="#245b7c" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#grad-2)" rx="32" />
+  <g fill="none" stroke="rgba(255,255,255,0.4)" stroke-width="8">
+    <rect x="120" y="160" width="1360" height="580" rx="28" />
+    <rect x="160" y="220" width="1280" height="420" rx="20" />
+    <line x1="160" y1="320" x2="1440" y2="320" />
+    <line x1="160" y1="420" x2="1440" y2="420" />
+  </g>
+  <text x="140" y="140" fill="rgba(255,255,255,0.85)" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="700">Book table filters</text>
+  <text x="140" y="760" fill="rgba(255,255,255,0.7)" font-family="Inter, Arial, sans-serif" font-size="32">MedLibrary UI highlight #2</text>
+</svg>

--- a/public/gallery/slide-3.svg
+++ b/public/gallery/slide-3.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-label="Category navigation">
+  <defs>
+    <linearGradient id="grad-3" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#1f3b5c" />
+      <stop offset="100%" stop-color="#3485aa" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#grad-3)" rx="32" />
+  <g fill="none" stroke="rgba(255,255,255,0.4)" stroke-width="8">
+    <rect x="120" y="160" width="1360" height="580" rx="28" />
+    <rect x="160" y="220" width="1280" height="420" rx="20" />
+    <line x1="160" y1="320" x2="1440" y2="320" />
+    <line x1="160" y1="420" x2="1440" y2="420" />
+  </g>
+  <text x="140" y="140" fill="rgba(255,255,255,0.85)" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="700">Category navigation</text>
+  <text x="140" y="760" fill="rgba(255,255,255,0.7)" font-family="Inter, Arial, sans-serif" font-size="32">MedLibrary UI highlight #3</text>
+</svg>

--- a/public/gallery/slide-4.svg
+++ b/public/gallery/slide-4.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-label="Book details layout">
+  <defs>
+    <linearGradient id="grad-4" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#24445a" />
+      <stop offset="100%" stop-color="#3f97b5" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#grad-4)" rx="32" />
+  <g fill="none" stroke="rgba(255,255,255,0.4)" stroke-width="8">
+    <rect x="120" y="160" width="1360" height="580" rx="28" />
+    <rect x="160" y="220" width="1280" height="420" rx="20" />
+    <line x1="160" y1="320" x2="1440" y2="320" />
+    <line x1="160" y1="420" x2="1440" y2="420" />
+  </g>
+  <text x="140" y="140" fill="rgba(255,255,255,0.85)" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="700">Book details layout</text>
+  <text x="140" y="760" fill="rgba(255,255,255,0.7)" font-family="Inter, Arial, sans-serif" font-size="32">MedLibrary UI highlight #4</text>
+</svg>

--- a/public/gallery/slide-5.svg
+++ b/public/gallery/slide-5.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-label="Offline-ready cards">
+  <defs>
+    <linearGradient id="grad-5" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#274f6a" />
+      <stop offset="100%" stop-color="#47a5c3" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#grad-5)" rx="32" />
+  <g fill="none" stroke="rgba(255,255,255,0.4)" stroke-width="8">
+    <rect x="120" y="160" width="1360" height="580" rx="28" />
+    <rect x="160" y="220" width="1280" height="420" rx="20" />
+    <line x1="160" y1="320" x2="1440" y2="320" />
+    <line x1="160" y1="420" x2="1440" y2="420" />
+  </g>
+  <text x="140" y="140" fill="rgba(255,255,255,0.85)" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="700">Offline-ready cards</text>
+  <text x="140" y="760" fill="rgba(255,255,255,0.7)" font-family="Inter, Arial, sans-serif" font-size="32">MedLibrary UI highlight #5</text>
+</svg>

--- a/public/gallery/slide-6.svg
+++ b/public/gallery/slide-6.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-label="PWA install prompt">
+  <defs>
+    <linearGradient id="grad-6" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#2c5a74" />
+      <stop offset="100%" stop-color="#50b2cf" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#grad-6)" rx="32" />
+  <g fill="none" stroke="rgba(255,255,255,0.4)" stroke-width="8">
+    <rect x="120" y="160" width="1360" height="580" rx="28" />
+    <rect x="160" y="220" width="1280" height="420" rx="20" />
+    <line x1="160" y1="320" x2="1440" y2="320" />
+    <line x1="160" y1="420" x2="1440" y2="420" />
+  </g>
+  <text x="140" y="140" fill="rgba(255,255,255,0.85)" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="700">PWA install prompt</text>
+  <text x="140" y="760" fill="rgba(255,255,255,0.7)" font-family="Inter, Arial, sans-serif" font-size="32">MedLibrary UI highlight #6</text>
+</svg>

--- a/public/hero-preview.svg
+++ b/public/hero-preview.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1600 900" role="img" aria-label="Catalog preview">
+  <defs>
+    <linearGradient id="grad-1" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#0b1224" />
+      <stop offset="100%" stop-color="#1a2a4a" />
+    </linearGradient>
+  </defs>
+  <rect width="1600" height="900" fill="url(#grad-1)" rx="32" />
+  <g fill="none" stroke="rgba(255,255,255,0.4)" stroke-width="8">
+    <rect x="120" y="160" width="1360" height="580" rx="28" />
+    <rect x="160" y="220" width="1280" height="420" rx="20" />
+    <line x1="160" y1="320" x2="1440" y2="320" />
+    <line x1="160" y1="420" x2="1440" y2="420" />
+  </g>
+  <text x="140" y="140" fill="rgba(255,255,255,0.85)" font-family="Inter, Arial, sans-serif" font-size="48" font-weight="700">Catalog preview</text>
+  <text x="140" y="760" fill="rgba(255,255,255,0.7)" font-family="Inter, Arial, sans-serif" font-size="32">MedLibrary UI highlight #1</text>
+</svg>

--- a/src/components/gallery.html
+++ b/src/components/gallery.html
@@ -6,22 +6,22 @@
   </div>
   <div class="gallery-slider__viewport">
     <div class="slide">
-      <img src="/1.webp" data-i18n-attr="alt" data-i18n="gallery.slide1" loading="lazy" decoding="async" />
+      <img src="/gallery/slide-1.svg" data-i18n-attr="alt" data-i18n="gallery.slide1" loading="lazy" decoding="async" />
     </div>
     <div class="slide">
-      <img src="/2.webp" data-i18n-attr="alt" data-i18n="gallery.slide2" loading="lazy" decoding="async" />
+      <img src="/gallery/slide-2.svg" data-i18n-attr="alt" data-i18n="gallery.slide2" loading="lazy" decoding="async" />
     </div>
     <div class="slide">
-      <img src="/3.webp" data-i18n-attr="alt" data-i18n="gallery.slide3" loading="lazy" decoding="async" />
+      <img src="/gallery/slide-3.svg" data-i18n-attr="alt" data-i18n="gallery.slide3" loading="lazy" decoding="async" />
     </div>
     <div class="slide">
-      <img src="/4.webp" data-i18n-attr="alt" data-i18n="gallery.slide4" loading="lazy" decoding="async" />
+      <img src="/gallery/slide-4.svg" data-i18n-attr="alt" data-i18n="gallery.slide4" loading="lazy" decoding="async" />
     </div>
     <div class="slide">
-      <img src="/5.webp" data-i18n-attr="alt" data-i18n="gallery.slide5" loading="lazy" decoding="async" />
+      <img src="/gallery/slide-5.svg" data-i18n-attr="alt" data-i18n="gallery.slide5" loading="lazy" decoding="async" />
     </div>
     <div class="slide">
-      <img src="/6.webp" data-i18n-attr="alt" data-i18n="gallery.slide6" loading="lazy" decoding="async" />
+      <img src="/gallery/slide-6.svg" data-i18n-attr="alt" data-i18n="gallery.slide6" loading="lazy" decoding="async" />
     </div>
   </div>
   <button class="gallery-slider__control prev" type="button" data-i18n-attr="aria-label" data-i18n="gallery.prev">

--- a/src/components/hero.html
+++ b/src/components/hero.html
@@ -34,7 +34,7 @@
         </div>
         <div class="preview-card__image">
           <img
-            src="/1.webp"
+            src="/hero-preview.svg"
             data-i18n-attr="alt"
             data-i18n="preview.imageAlt"
             loading="lazy"

--- a/vite.config.js
+++ b/vite.config.js
@@ -18,12 +18,8 @@ export default defineConfig({
         { src: 'Book.xlsx', dest: '' },
         { src: 'Book.xls', dest: '' },
         { src: 'Book.mht', dest: '' },
-        { src: '1.webp', dest: '' },
-        { src: '2.webp', dest: '' },
-        { src: '3.webp', dest: '' },
-        { src: '4.webp', dest: '' },
-        { src: '5.webp', dest: '' },
-        { src: '6.webp', dest: '' }
+        { src: 'public/hero-preview.svg', dest: '' },
+        { src: 'public/gallery', dest: 'gallery' }
       ]
     })
   ]


### PR DESCRIPTION
## Summary
- add bundled SVG illustrations for the hero preview and gallery carousel to replace missing images
- update hero and gallery components to load the new assets
- adjust Vite static copy configuration to ship the added artwork

## Testing
- npm run build *(fails: vite package unavailable in environment due to registry access restrictions)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923489e3be88329b2ee66c029c89847)