### PR TITLE
Add CLI options to catalog builder

### DIFF
--- a/scripts/build_catalog.py
+++ b/scripts/build_catalog.py
@@ -1,3 +1,4 @@
+import argparse
 import csv
 import json
 from pathlib import Path
@@ -126,8 +127,8 @@ def select_value(row: dict[str, str], aliases: Iterable[str]) -> str:
     return ""
 
 
-def load_rows() -> list[dict[str, str | int]]:
-    with TSV_PATH.open("r", encoding="utf-8") as handle:
+def load_rows(source_path: Path) -> list[dict[str, str | int]]:
+    with source_path.open("r", encoding="utf-8") as handle:
         reader = csv.DictReader(handle, delimiter="\t")
         results: list[dict[str, str | int]] = []
         for row in reader:
@@ -149,12 +150,38 @@ def load_rows() -> list[dict[str, str | int]]:
 
 
 def main() -> None:
-    rows = load_rows()
-    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-    with OUTPUT_PATH.open("w", encoding="utf-8") as handle:
+    parser = argparse.ArgumentParser(
+        description="Normalize MedLibrary TSV catalog into JSON"
+    )
+    parser.add_argument(
+        "--input",
+        type=Path,
+        default=TSV_PATH,
+        help="Path to the TSV source (defaults to books.html)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=OUTPUT_PATH,
+        help="Destination JSON path (defaults to data/books.json)",
+    )
+    args = parser.parse_args()
+
+    source_path = args.input.resolve()
+    output_path = args.output.resolve()
+
+    if not source_path.exists():
+        raise SystemExit(f"Source file not found: {source_path}")
+
+    rows = load_rows(source_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    with output_path.open("w", encoding="utf-8") as handle:
         json.dump(rows, handle, ensure_ascii=False, indent=2)
         handle.write("\n")
-    relative = OUTPUT_PATH.relative_to(REPO_ROOT)
+    try:
+        relative = output_path.relative_to(REPO_ROOT)
+    except ValueError:
+        relative = output_path
     print(f"Saved {len(rows)} records to {relative}")
 
 


### PR DESCRIPTION
## Summary
- add CLI arguments to the catalog conversion script so input and output paths can be overridden
- validate the TSV source path before processing and keep relative output logging when possible

## Testing
- python scripts/build_catalog.py --input books.html --output data/books.json


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69234a2608408329bf29624e6ebfdf12)