### PR TITLE
Fix static frontend loading without bundler

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
     <meta name="theme-color" content="#0b1224" />
     <meta name="description" data-i18n="meta.description" data-i18n-target="content" />
     <title data-i18n="meta.title"></title>
+    <link rel="stylesheet" href="./styles.css" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link


### PR DESCRIPTION
## Summary
- ensure the landing page pulls in its stylesheet without relying on Vite bundling
- refactor the frontend bootstrap to fetch component fragments and translations at runtime so it can load when served statically
- add a graceful error message if component loading fails

## Testing
- npm install *(fails: registry access forbidden in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923985c882c8329b909b91047d30d36)