### PR TITLE
Improve service worker asset caching and fallbacks

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,4 +1,4 @@
-const CACHE_NAME = 'medlibrary-v6';
+const CACHE_NAME = 'medlibrary-v7';
 const APP_SHELL = [
   './',
   './index.html',
@@ -13,6 +13,19 @@ const APP_SHELL = [
   './config.js',
   './lang.js',
   './pwa.js',
+  './src/main.js',
+  './src/components/header.html',
+  './src/components/hero.html',
+  './src/components/audit.html',
+  './src/components/features.html',
+  './src/components/catalog-preview.html',
+  './src/components/platform.html',
+  './src/components/gallery.html',
+  './src/components/contact.html',
+  './src/components/footer.html',
+  './src/i18n/en.json',
+  './src/i18n/ru.json',
+  './src/i18n/tm.json',
   './manifest.webmanifest',
   './data/books.json',
   './Book.xlsx',
@@ -59,20 +72,26 @@ self.addEventListener('fetch', (event) => {
 
   const normalizedPath = url.pathname === '/' ? './' : `.${url.pathname}`;
   if (APP_SHELL.includes(normalizedPath) || request.destination === 'document') {
-    event.respondWith(networkFirst(request));
-  } else {
-    event.respondWith(cacheFirst(request));
+    event.respondWith(networkFirst(request, { fallbackToShell: true }));
+    return;
   }
+
+  event.respondWith(cacheFirst(request));
 });
 
-function networkFirst(request) {
+function networkFirst(request, options = {}) {
   return fetch(request)
     .then((response) => {
       const copy = response.clone();
       caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
       return response;
     })
-    .catch(() => caches.match(request).then((cached) => cached || caches.match('./index.html')));
+    .catch(() => {
+      if (options.fallbackToShell && request.destination === 'document') {
+        return caches.match('./index.html');
+      }
+      return caches.match(request);
+    });
 }
 
 function cacheFirst(request) {
@@ -86,6 +105,6 @@ function cacheFirst(request) {
         caches.open(CACHE_NAME).then((cache) => cache.put(request, copy));
         return response;
       })
-      .catch(() => caches.match('./index.html'));
+      .catch(() => caches.match(request));
   });
 }


### PR DESCRIPTION
## Summary
- expand the service worker app shell to cache component partials, translations, and the main entry file
- adjust fetch handling to avoid HTML fallbacks for non-document requests and bump the cache version

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239aedf2348329aecece9f9fc0ec98)