### PR TITLE
Implement working contact form submission

### DIFF
--- a/config.js
+++ b/config.js
@@ -3,6 +3,7 @@
 window.__APP_CONFIG__ = window.__APP_CONFIG__ || {
   apiBase: '',
   googleClientId: '',
+  contactEndpoint: '',
 };
 
 (function applyRuntimeConfig(config) {
@@ -20,6 +21,10 @@ window.__APP_CONFIG__ = window.__APP_CONFIG__ || {
       if (googleMeta) {
         googleMeta.content = config.googleClientId;
       }
+    }
+
+    if (config.contactEndpoint) {
+      body.dataset.contactEndpoint = config.contactEndpoint;
     }
   };
 

--- a/src/components/contact.html
+++ b/src/components/contact.html
@@ -4,7 +4,7 @@
     <h2 class="section__title" data-i18n="contact.title"></h2>
     <p class="section__subtitle" data-i18n="contact.subtitle"></p>
   </div>
-  <form class="contact__form" onsubmit="sendMail(); return false;">
+  <form class="contact__form" id="contactForm" onsubmit="sendMail(event); return false;">
     <label class="form-group">
       <span data-i18n="contact.name"></span>
       <input type="text" id="name" name="name" required data-i18n-attr="placeholder" data-i18n-placeholder="contact.namePlaceholder" />


### PR DESCRIPTION
## Summary
- allow configuring a contact endpoint at runtime for GitHub Pages or API deployments
- replace the mailto-based contact form with a fetch submission flow using translated status messages
- add client-side validation and disable the submit button while sending

## Testing
- npm install *(fails: registry.npmjs.org/vite returned 403 Forbidden in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69239cbb380c8329b543154a41b24e7a)