### PR TITLE
Remove binary MRI template and update Turkmen text

### DIFF
--- a/Beýni_kada_.md
+++ b/Beýni_kada_.md
@@ -1,0 +1,41 @@
+# BEÝNI MRT KADASY (ŞABLON)
+
+Bu faýl beýniniň MRT barlagy üçin ýeke-täk resmi şablondyr we ähli beýni MRT düşündirişleri şu görnüşe laýyklykda taýýarlandy.
+
+Pasýent: ____________________________________    Ýaşy: _____    Jynsy: _____
+Barlag senesi we wagty: _____________________
+Öňki MRT bilen deňeşdirme: bar / ýok (senesi: _____________________)
+Haýyş ediji lukman: _____________________
+Indikasiýa / esasy şikaýatlar: _____________________________________________________
+Kontrast serişdesi: ýok / bar (ady, doza, damardan berýärsiňizmi): _____________________
+Täzelik / taýýarlyk (sedasiýa, ýörite şertler): ______________________________________
+
+**Protokol gysgaça:** magnit güýji: _____ T; dilim galyňlygy: _____ mm; meýilnamalar: aksial / sagital / koronal; sekvensiýalar: T1, T2, FLAIR, DWI/ADC, SWI/T2*, T1 FS, MRA (zerur bolsa).
+
+## Tapyndylar (boş ýerleri dolduryň)
+1. Serebral gyralar we ak-madda: _____________________________________________________
+2. Korpus kallosum we orta çyzyk: __________________________________________________
+3. Periventrikulýar we subkortikal ugurlar: _________________________________________
+4. Bazal gangliýalar, talamus, içki kapsula: ______________________________________
+5. Beýnagyzyň baldagy (mezensefalon, pon, medulla): __________________________________
+6. Kiçi beýni we vermis: ____________________________________________________________
+7. Ventikulýar ulgam we subaraknoid giňişlik: ölçegleri, simmetriýasy, giňelme / daralma: ______________________________________________________________
+8. Hipofiz, suprazellar giňişlik we optiki traktlar: ________________________________
+9. Paranazal sinuslar, mastoid öýjükleri, ýumşak dokumalar: _________________________
+10. Gozgalaňly signal üýtgemeleri (ishemia, demýelinizasiýa, neoplaziýa, demir toplanmasy): _____________________________________________________________
+11. Hemoragiýa / gematosiderin yzlary (SWI/T2*): ____________________________________
+12. DWI/ADC: diffuziýa çäklendirilmesi ýa-da peselmesi: _____________________________
+13. Postkontrast güýçlenme (eger berlen bolsa): görnüşi, ýerleşişi: _________________
+14. Damarlaryň konfigurasiýasy (TOF MRA ýa-da beýlekisi): stenoz / aneurizma / AVM: ___
+15. Boyun girişleri we baza süňkler: _______________________________________________
+
+## Netije
+- ____________________________________________________________________________
+- ____________________________________________________________________________
+- ____________________________________________________________________________
+
+**Maslahatlar / teklipler:** ____________________________________________________________
+
+Barlagy ýerine ýetiren lukman: _____________________
+
+Gol / möhür üçin ýer: _____________________


### PR DESCRIPTION
## Summary
- remove the binary DOCX MRI template to keep only text-based assets
- update the Turkmen MRI kadase markdown to serve as the canonical template

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692416e687808329a6f1bf617193a392)