### PR TITLE
Improve landing page UX, accessibility, and async controls

### DIFF
--- a/FRONTEND_ANALYSIS.md
+++ b/FRONTEND_ANALYSIS.md
@@ -20,3 +20,11 @@
 - Align language initialization with the selected option or persist the user’s preference in storage to avoid conflicting defaults. Replace the current `setLanguage('tm')` call with logic that reads the selector value or a saved preference. 【F:index.html†L34-L45】【F:lang.js†L1-L36】
 - Move translations into JSON locale files and render text via a lightweight i18n utility so that markup stays DRY and future languages do not require tripling every block of content. 【F:index.html†L34-L164】【F:lang.js†L2-L8】
 - Consider lazy-loading heavier catalog assets and deferring non-critical scripts to improve initial render on low-end devices, keeping the landing experience focused on the primary CTAs. 【F:index.html†L74-L200】
+
+## 2026-05-13 follow-up improvements
+- Added an immediately visible loading state, a no-script warning, and a keyboard skip link so the landing page is not blank while modular components/translations are being fetched and keyboard users can jump straight to content. 【F:index.html†L40-L53】【F:styles.css†L48-L106】
+- Made the injected `<main>` target explicit and focusable for skip-link navigation, and clear `aria-busy` on both successful and failed layout loads. 【F:src/main.js†L166-L184】【F:src/main.js†L196-L200】
+- Fixed the modular language switcher to normalize unsupported languages, apply the same active classes as the legacy script/CSS, and expose `aria-pressed` for assistive technologies. 【F:src/main.js†L55-L105】
+- Initialized the gallery slider after the async component injection, including pause-on-hover/focus and reduced-motion-aware scrolling, so controls keep working even when `scripts.js` runs before components exist. 【F:src/main.js†L116-L159】
+- Re-registered PWA install buttons after the modular layout is injected, then updated footer copyright strings for 2026 and corrected the English category count to 67 to match the rest of the site copy. 【F:pwa.js†L73-L76】
+- Updated footer copyright strings for 2026 and corrected the English category count to 67 to match the rest of the site copy. 【F:src/i18n/en.json†L54-L57】【F:src/i18n/en.json†L136-L139】

--- a/index.html
+++ b/index.html
@@ -38,7 +38,16 @@
     <script src="./config.js"></script>
   </head>
   <body class="home">
-    <div id="app"></div>
+    <a class="skip-link" href="#main-content">Перейти к содержимому</a>
+    <div id="app" aria-busy="true">
+      <div class="app-loading" role="status" aria-live="polite">
+        <span class="app-loading__spinner" aria-hidden="true"></span>
+        <span>Загружаем MedLibrary…</span>
+      </div>
+    </div>
+    <noscript>
+      <div class="noscript-alert">Для работы интерактивного каталога MedLibrary включите JavaScript.</div>
+    </noscript>
 
     <script type="module" src="./src/main.js"></script>
     <script defer src="./scripts.js"></script>

--- a/pwa.js
+++ b/pwa.js
@@ -73,5 +73,6 @@
 
   registerButtons();
   document.addEventListener('DOMContentLoaded', registerButtons);
+  document.addEventListener('medlibrary:layout-ready', registerButtons);
   window.addEventListener('load', registerServiceWorker);
 })();

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -61,7 +61,7 @@
     },
     "categories": {
       "title": "BooksMed categories",
-      "text": "69 familiar directions. One click to jump to the right field of knowledge."
+      "text": "67 familiar directions. One click to jump to the right field of knowledge."
     },
     "search": {
       "title": "Noise-free search",
@@ -138,7 +138,7 @@
     "emailAddress": "tdlipf@gmail.com"
   },
   "footer": {
-    "copyright": "© 2025 MedLibrary",
+    "copyright": "© 2026 MedLibrary",
     "tagline": "Medical digital library."
   }
 }

--- a/src/i18n/ru.json
+++ b/src/i18n/ru.json
@@ -138,7 +138,7 @@
     "emailAddress": "tdlipf@gmail.com"
   },
   "footer": {
-    "copyright": "© 2025 MedLibrary",
+    "copyright": "© 2026 MedLibrary",
     "tagline": "Медицинская электронная библиотека."
   }
 }

--- a/src/i18n/tm.json
+++ b/src/i18n/tm.json
@@ -138,7 +138,7 @@
     "emailAddress": "tdlipf@gmail.com"
   },
   "footer": {
-    "copyright": "© 2025 MedLibrary",
+    "copyright": "© 2026 MedLibrary",
     "tagline": "Lukmançylyk elektron kitaphanasy."
   }
 }

--- a/src/main.js
+++ b/src/main.js
@@ -60,15 +60,17 @@ function getTranslation(lang, key) {
 }
 
 function applyTranslations(lang) {
-  document.documentElement.lang = lang;
-  document.documentElement.dataset.lang = lang;
+  const normalizedLang = translations[lang] ? lang : 'ru';
 
-  const dictionary = translations[lang] || translations.ru || {};
+  document.documentElement.lang = normalizedLang;
+  document.documentElement.dataset.lang = normalizedLang;
+
+  const dictionary = translations[normalizedLang] || translations.ru || {};
 
   document.querySelectorAll('[data-i18n]').forEach(element => {
     const key = element.dataset.i18n;
     const attr = element.dataset.i18nAttr || element.dataset.i18nTarget;
-    const translation = getTranslation(lang, key);
+    const translation = getTranslation(normalizedLang, key);
 
     if (!translation) {
       return;
@@ -83,7 +85,7 @@ function applyTranslations(lang) {
 
   document.querySelectorAll('[data-i18n-placeholder]').forEach(element => {
     const key = element.dataset.i18nPlaceholder;
-    const translation = getTranslation(lang, key);
+    const translation = getTranslation(normalizedLang, key);
     if (translation) {
       element.setAttribute('placeholder', translation);
     }
@@ -100,7 +102,10 @@ function applyTranslations(lang) {
   }
 
   document.querySelectorAll('.lang-switch [data-lang]').forEach(button => {
-    button.classList.toggle('lang-switch__active', button.dataset.lang === lang);
+    const isActive = button.dataset.lang === normalizedLang;
+    button.classList.toggle('is-active', isActive);
+    button.classList.toggle('lang-switch__active', isActive);
+    button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
   });
 }
 
@@ -120,14 +125,76 @@ function initLanguage() {
   applyTranslations(initialLanguage);
 }
 
+function initGallerySlider() {
+  const slider = document.querySelector('.gallery-slider');
+  if (!slider || slider.dataset.sliderReady === 'true') {
+    return;
+  }
+
+  const viewport = slider.querySelector('.gallery-slider__viewport');
+  const slides = Array.from(slider.querySelectorAll('.slide'));
+  const nextButton = slider.querySelector('.next');
+  const prevButton = slider.querySelector('.prev');
+
+  if (!viewport || slides.length < 2) {
+    return;
+  }
+
+  slider.dataset.sliderReady = 'true';
+  let currentSlide = 0;
+  let timerId;
+
+  const renderSlides = () => {
+    slides.forEach((slide, index) => {
+      slide.setAttribute('aria-hidden', index === currentSlide ? 'false' : 'true');
+    });
+    viewport.scrollTo({
+      left: viewport.clientWidth * currentSlide,
+      behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches ? 'auto' : 'smooth',
+    });
+  };
+
+  const goToSlide = direction => {
+    currentSlide = (currentSlide + direction + slides.length) % slides.length;
+    renderSlides();
+  };
+
+  const restartTimer = () => {
+    window.clearInterval(timerId);
+    timerId = window.setInterval(() => goToSlide(1), 10000);
+  };
+
+  nextButton?.addEventListener('click', () => {
+    goToSlide(1);
+    restartTimer();
+  });
+  prevButton?.addEventListener('click', () => {
+    goToSlide(-1);
+    restartTimer();
+  });
+
+  slider.addEventListener('mouseenter', () => window.clearInterval(timerId));
+  slider.addEventListener('mouseleave', restartTimer);
+  slider.addEventListener('focusin', () => window.clearInterval(timerId));
+  slider.addEventListener('focusout', restartTimer);
+
+  renderSlides();
+  restartTimer();
+}
+
+function dispatchLayoutReady() {
+  document.dispatchEvent(new CustomEvent('medlibrary:layout-ready'));
+}
+
 function injectLayout(components) {
   const app = document.getElementById('app');
   if (!app) return;
 
+  app.setAttribute('aria-busy', 'false');
   app.innerHTML = `
     <div class="page">
       ${components.header || ''}
-      <main>
+      <main id="main-content" tabindex="-1">
         ${components.hero || ''}
         ${components.audit || ''}
         ${components.features || ''}
@@ -147,11 +214,14 @@ async function init() {
     injectLayout(components);
     initLanguage();
     bindLanguageSwitch();
+    initGallerySlider();
+    dispatchLayoutReady();
   } catch (error) {
     console.error(error);
     const app = document.getElementById('app');
     if (app) {
-      app.innerHTML = '<p class="text-center">Не удалось загрузить интерфейс. Попробуйте обновить страницу.</p>';
+      app.setAttribute('aria-busy', 'false');
+      app.innerHTML = '<p class="text-center app-error" role="alert">Не удалось загрузить интерфейс. Попробуйте обновить страницу.</p>';
     }
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -46,6 +46,62 @@ a {
   padding-inline: clamp(1rem, 4vw, 2rem);
 }
 
+
+.skip-link {
+  position: fixed;
+  top: 0.75rem;
+  left: 0.75rem;
+  z-index: 1000;
+  padding: 0.7rem 1rem;
+  border-radius: 999px;
+  background: var(--text);
+  color: #fff;
+  font-weight: 700;
+  box-shadow: var(--shadow);
+  transform: translateY(-140%);
+  transition: transform 0.2s ease;
+}
+
+.skip-link:focus {
+  transform: translateY(0);
+  outline: 3px solid var(--primary-2);
+  outline-offset: 3px;
+}
+
+.app-loading,
+.noscript-alert,
+.app-error {
+  width: min(720px, calc(100% - 2rem));
+  margin: clamp(2rem, 10vh, 5rem) auto;
+  padding: 1.25rem;
+  border: 1px solid var(--border);
+  border-radius: 18px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  color: var(--muted);
+  text-align: center;
+}
+
+.app-loading {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.75rem;
+}
+
+.app-loading__spinner {
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 50%;
+  border: 3px solid var(--border);
+  border-top-color: var(--primary);
+  animation: app-loading-spin 0.8s linear infinite;
+}
+
+@keyframes app-loading-spin {
+  to { transform: rotate(360deg); }
+}
+
 main {
   display: flex;
   flex-direction: column;
@@ -163,7 +219,8 @@ main {
   outline: none;
 }
 
-.lang-switch button.is-active {
+.lang-switch button.is-active,
+.lang-switch button.lang-switch__active {
   color: #fff;
   background: linear-gradient(120deg, var(--primary), var(--primary-2));
   box-shadow: 0 8px 20px rgba(26, 108, 255, 0.2);
@@ -885,6 +942,17 @@ main {
 .auth-session { padding: 0 1.25rem 1.25rem; border-top: 1px solid var(--border); }
 
 /* Gallery buttons in mobile */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    scroll-behavior: auto !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+
 @media (max-width: 640px) {
   .site-header__bar { grid-template-columns: 1fr; }
   .site-footer__content { flex-direction: column; align-items: flex-start; }
@@ -1180,8 +1248,8 @@ main {
 }
 
 .lang-switch__active {
-  background-color: #0b1224;
-  color: #f8f9fb;
+  color: #fff;
+  background: linear-gradient(120deg, var(--primary), var(--primary-2));
 }
 
 /* Video lessons page */


### PR DESCRIPTION
### Motivation
- Ensure the landing page is usable and discoverable while async components and translations load and improve keyboard/accessibility affordances. 
- Make the modular language switching resilient and accessible so unsupported languages fall back predictably and assistive tech exposes state. 
- Ensure interactive controls (gallery slider, PWA install buttons) initialize reliably after the layout is injected. 
- Refresh localized copy (year and category count) and record the follow-up improvements in the frontend analysis. 

### Description
- Added an upfront loading UI, a `noscript` message and a keyboard `skip-link` and corresponding CSS so the page is not blank while modules load. 
- Made the injected `<main>` focusable, manage `aria-busy` on the `#app` wrapper, and dispatch a `medlibrary:layout-ready` event after layout injection. 
- Hardened language rendering to normalize unknown languages to `ru`, apply consistent active classes and set `aria-pressed`, and moved translation lookups to use the normalized language. 
- Initialized the gallery slider after component injection (pause on hover/focus, reduced-motion aware) and re-registered PWA install buttons on the `medlibrary:layout-ready` event; updated locale files (`src/i18n/*.json`) with copyright 2026 and corrected English category count. 

### Testing
- Ran `node --check src/main.js`, `node --check pwa.js`, and `node --check scripts.js` and they all succeeded. 
- Ran `git diff --check` and `git status` checks with no issues reported. 
- `npm ci` failed due to registry `403 Forbidden` when fetching `vite`, so full dependency install was not possible. 
- `npm run build` could not run because `vite` is not installed locally (`sh: 1: vite: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a04ebe10c3483299ff2689a4abddfb4)